### PR TITLE
refactor(server): drive routes and logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@sindresorhus/is": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
+      "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
+    },
     "accepts": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
@@ -25,31 +30,10 @@
       "integrity": "sha1-8u4fMiipDurRJF+asZIusucdM2s=",
       "dev": true
     },
-    "ajv": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
-      "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
-      "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.0.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
-      }
-    },
     "ansi-escapes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
       "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
-    },
-    "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-    },
-    "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
     "array-filter": {
       "version": "1.0.0",
@@ -62,44 +46,17 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
-    "asn1": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
-    },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
-    "async": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
-      "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
-      "requires": {
-        "lodash": "4.17.4"
-      }
-    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-    },
-    "aws4": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "axios": {
       "version": "0.17.1",
@@ -116,58 +73,12 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
-    "base64url": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/base64url/-/base64url-1.0.6.tgz",
-      "integrity": "sha1-1k03XWinxkDZEuI1jRcNylu1RoE=",
-      "requires": {
-        "concat-stream": "1.4.10",
-        "meow": "2.0.0"
-      }
-    },
     "basic-auth": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.0.tgz",
       "integrity": "sha1-AV2z81PgLlY3d1X5YnQuiYHnu7o=",
       "requires": {
         "safe-buffer": "5.1.1"
-      }
-    },
-    "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "optional": true,
-      "requires": {
-        "tweetnacl": "0.14.5"
-      }
-    },
-    "bl": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
-      "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
-      "requires": {
-        "readable-stream": "2.0.6"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "0.10.31",
-            "util-deprecate": "1.0.2"
-          }
-        }
       }
     },
     "bluebird": {
@@ -239,25 +150,6 @@
       "integrity": "sha1-qEq8glpV70yysCi9dOIFpluaSZY=",
       "dev": true
     },
-    "camelcase": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
-    },
-    "camelcase-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-      "integrity": "sha1-vRoRv5sxoc5JNJOpMN4aC69K1+w=",
-      "requires": {
-        "camelcase": "1.2.1",
-        "map-obj": "1.0.1"
-      }
-    },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-    },
     "chai": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
@@ -267,18 +159,6 @@
         "assertion-error": "1.1.0",
         "deep-eql": "0.1.3",
         "type-detect": "1.0.0"
-      }
-    },
-    "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
       }
     },
     "chardet": {
@@ -307,11 +187,6 @@
         "cookies": "0.7.1"
       }
     },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
-    },
     "color-convert": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
@@ -329,6 +204,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "dev": true,
       "requires": {
         "delayed-stream": "1.0.0"
       }
@@ -336,7 +212,8 @@
     "commander": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "dev": true
     },
     "component-emitter": {
       "version": "1.2.1",
@@ -349,16 +226,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
-    },
-    "concat-stream": {
-      "version": "1.4.10",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
-      "integrity": "sha1-rMO79WAsuMyYDGrIQPp9hgPj7zY=",
-      "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "1.1.14",
-        "typedarray": "0.0.6"
-      }
     },
     "content-disposition": {
       "version": "0.5.2",
@@ -404,38 +271,13 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "cryptiles": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-      "requires": {
-        "boom": "5.2.0"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        }
-      }
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "crypto-random-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
-    },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "requires": {
-        "assert-plus": "1.0.0"
-      }
     },
     "debug": {
       "version": "2.6.9",
@@ -481,7 +323,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "depd": {
       "version": "1.1.1",
@@ -505,195 +348,11 @@
       "integrity": "sha1-HMPIOkkNZ/ldkeOfatHy4Ia2MEg=",
       "dev": true
     },
-    "drive-config": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/drive-config/-/drive-config-0.1.1.tgz",
-      "integrity": "sha1-tYcrhLyfqr3PP2ny6g9jO9r5ZMI=",
-      "requires": {
-        "googleapis": "12.4.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
-        },
-        "boom": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "caseless": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-          "requires": {
-            "boom": "2.10.1"
-          }
-        },
-        "form-data": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
-          "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
-          "requires": {
-            "async": "2.0.1",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
-          }
-        },
-        "google-auth-library": {
-          "version": "0.9.10",
-          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-0.9.10.tgz",
-          "integrity": "sha1-SZPcB7tINLjKA1AhOmhzoyxgUbk=",
-          "requires": {
-            "async": "1.4.2",
-            "gtoken": "1.2.3",
-            "jws": "3.0.0",
-            "lodash.noop": "3.0.1",
-            "request": "2.74.0",
-            "string-template": "0.2.1"
-          },
-          "dependencies": {
-            "async": {
-              "version": "1.4.2",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz",
-              "integrity": "sha1-bJ7csRztTw3S8tQNsNSaEJwIiqs="
-            },
-            "request": {
-              "version": "2.74.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
-              "integrity": "sha1-dpPKdou7DqXIzgjAhKRe+gW4kqs=",
-              "requires": {
-                "aws-sign2": "0.6.0",
-                "aws4": "1.6.0",
-                "bl": "1.1.2",
-                "caseless": "0.11.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "1.0.1",
-                "har-validator": "2.0.6",
-                "hawk": "3.1.3",
-                "http-signature": "1.1.1",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.17",
-                "node-uuid": "1.4.8",
-                "oauth-sign": "0.8.2",
-                "qs": "6.2.3",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.3",
-                "tunnel-agent": "0.4.3"
-              }
-            },
-            "string-template": {
-              "version": "0.2.1",
-              "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
-              "integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0="
-            }
-          }
-        },
-        "googleapis": {
-          "version": "12.4.0",
-          "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-12.4.0.tgz",
-          "integrity": "sha1-kbKRbQE02dg/vrXbs8/3Qjqzfok=",
-          "requires": {
-            "async": "2.0.1",
-            "google-auth-library": "0.9.10",
-            "request": "2.83.0",
-            "string-template": "1.0.0"
-          }
-        },
-        "har-validator": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-          "requires": {
-            "chalk": "1.1.3",
-            "commander": "2.11.0",
-            "is-my-json-valid": "2.16.1",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
-          }
-        },
-        "node-uuid": {
-          "version": "1.4.8",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
-        },
-        "qs": {
-          "version": "6.2.3",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
-          "integrity": "sha1-HPyyXBCpsrSDBT/zn138kjOQjP4="
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
-        }
-      }
-    },
     "eastasianwidth": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.1.1.tgz",
       "integrity": "sha1-RNZW3p2kFWlEZzNTZfsxR7hXK3w=",
       "dev": true
-    },
-    "ecc-jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "optional": true,
-      "requires": {
-        "jsbn": "0.1.1"
-      }
     },
     "ecdsa-sig-formatter": {
       "version": "1.0.9",
@@ -823,7 +482,8 @@
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "dev": true
     },
     "external-editor": {
       "version": "2.1.0",
@@ -834,21 +494,6 @@
         "iconv-lite": "0.4.19",
         "tmp": "0.0.33"
       }
-    },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-    },
-    "fast-deep-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
-    },
-    "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "figures": {
       "version": "2.0.0",
@@ -903,15 +548,11 @@
       "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
       "dev": true
     },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-    },
     "form-data": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
       "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+      "dev": true,
       "requires": {
         "asynckit": "0.4.0",
         "combined-stream": "1.0.5",
@@ -940,37 +581,11 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "generate-function": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
-    },
-    "generate-object-property": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "requires": {
-        "is-property": "1.0.2"
-      }
-    },
     "get-caller-file": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
       "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
       "dev": true
-    },
-    "get-stdin": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
-    },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "requires": {
-        "assert-plus": "1.0.0"
-      }
     },
     "glob": {
       "version": "7.1.2",
@@ -1052,14 +667,6 @@
         }
       }
     },
-    "google-p12-pem": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-0.1.2.tgz",
-      "integrity": "sha1-M8RqsCGqc0+gMys5YKmj/8svMXc=",
-      "requires": {
-        "node-forge": "0.7.1"
-      }
-    },
     "googleapis": {
       "version": "25.0.0",
       "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-25.0.0.tgz",
@@ -1088,75 +695,16 @@
       "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
       "dev": true
     },
-    "gtoken": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-1.2.3.tgz",
-      "integrity": "sha512-wQAJflfoqSgMWrSBk9Fg86q+sd6s7y6uJhIvvIPz++RElGlMtEqsdAR2oWwZ/WTEtp7P9xFbJRrT976oRgzJ/w==",
-      "requires": {
-        "google-p12-pem": "0.1.2",
-        "jws": "3.0.0",
-        "mime": "1.4.1",
-        "request": "2.83.0"
-      }
-    },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-    },
-    "har-validator": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-      "requires": {
-        "ajv": "5.3.0",
-        "har-schema": "2.0.0"
-      }
-    },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "requires": {
-        "ansi-regex": "2.1.1"
-      }
-    },
     "has-flag": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
       "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
-    },
-    "hawk": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-      "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.0",
-        "sntp": "2.1.0"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-          "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        }
-      }
     },
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
-    },
-    "hoek": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
     },
     "http-errors": {
       "version": "1.6.2",
@@ -1169,30 +717,10 @@
         "statuses": "1.4.0"
       }
     },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.13.1"
-      }
-    },
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
       "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
-    },
-    "indent-string": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
-      "integrity": "sha1-25m8xYPrarux5I3LsZmamGBBy2s=",
-      "requires": {
-        "get-stdin": "4.0.1",
-        "minimist": "1.2.0",
-        "repeating": "1.1.3"
-      }
     },
     "indexof": {
       "version": "0.0.1",
@@ -1286,49 +814,15 @@
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
-    "is-finite": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "requires": {
-        "number-is-nan": "1.0.1"
-      }
-    },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
     },
-    "is-my-json-valid": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
-      "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
-      "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
-      }
-    },
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
-    },
-    "is-property": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
-    },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-    },
-    "isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "isemail": {
       "version": "3.1.0",
@@ -1344,11 +838,6 @@
           "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
         }
       }
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "joi": {
       "version": "13.1.1",
@@ -1367,26 +856,11 @@
         }
       }
     },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "optional": true
-    },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-    },
-    "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
-    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "json-validation": {
       "version": "1.0.4",
@@ -1394,48 +868,6 @@
       "integrity": "sha1-qQkSlhVNW4ipno380nzIec0ZNWw=",
       "requires": {
         "underscore": "1.3.3"
-      }
-    },
-    "jsonpointer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
-    },
-    "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
-      }
-    },
-    "jwa": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.0.2.tgz",
-      "integrity": "sha1-/Xlgnx53Limdzo3bdtAGWd2DUR8=",
-      "requires": {
-        "base64url": "0.0.6",
-        "buffer-equal-constant-time": "1.0.1",
-        "ecdsa-sig-formatter": "1.0.9"
-      },
-      "dependencies": {
-        "base64url": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz",
-          "integrity": "sha1-lZezazMNscQkdzIuqH6oAnSZuCs="
-        }
-      }
-    },
-    "jws": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.0.0.tgz",
-      "integrity": "sha1-2l8meJfdTpz4E3l52zP8VKPAVBg=",
-      "requires": {
-        "base64url": "1.0.6",
-        "jwa": "1.0.2"
       }
     },
     "keygrip": {
@@ -1453,11 +885,6 @@
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
-    "lodash.noop": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-3.0.1.tgz",
-      "integrity": "sha1-OBiPTWUKOkdCWEObluxFsyYXEzw="
-    },
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
@@ -1467,26 +894,10 @@
         "yallist": "2.1.2"
       }
     },
-    "map-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
-    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
-    },
-    "meow": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
-      "integrity": "sha1-j1MKjs9dQNP0tN+Tw0cpAPuiqPE=",
-      "requires": {
-        "camelcase-keys": "1.0.0",
-        "indent-string": "1.2.2",
-        "minimist": "1.2.0",
-        "object-assign": "1.0.0"
-      }
     },
     "merge-descriptors": {
       "version": "1.0.1",
@@ -1529,11 +940,6 @@
       "requires": {
         "brace-expansion": "1.1.8"
       }
-    },
-    "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -1647,11 +1053,6 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.1.tgz",
       "integrity": "sha1-naYR6giYL0uUIGs760zJZl8gwwA="
-    },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nyc": {
       "version": "11.4.1",
@@ -3247,16 +2648,6 @@
         }
       }
     },
-    "oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
-    },
-    "object-assign": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz",
-      "integrity": "sha1-5l3Idm07R7S4MHRlyDEdoDCwcKY="
-    },
     "object-keys": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
@@ -3314,28 +2705,10 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-    },
     "pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-    },
-    "pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "requires": {
-        "pinkie": "2.0.4"
-      }
     },
     "power-assert": {
       "version": "1.4.4",
@@ -3460,7 +2833,8 @@
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "dev": true
     },
     "propagate": {
       "version": "0.4.0",
@@ -3482,11 +2856,6 @@
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
-    "punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-    },
     "qs": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
@@ -3506,54 +2875,6 @@
         "http-errors": "1.6.2",
         "iconv-lite": "0.4.19",
         "unpipe": "1.0.0"
-      }
-    },
-    "readable-stream": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-      "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "0.0.1",
-        "string_decoder": "0.10.31"
-      }
-    },
-    "repeating": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-      "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
-      "requires": {
-        "is-finite": "1.0.2"
-      }
-    },
-    "request": {
-      "version": "2.83.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
-      "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.6.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.1",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.17",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.1",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.3",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
       }
     },
     "restore-cursor": {
@@ -3640,29 +2961,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
-    "sntp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-      "requires": {
-        "hoek": "4.2.0"
-      }
-    },
-    "sshpk": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-      "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
-      }
-    },
     "statuses": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
@@ -3697,11 +2995,6 @@
         }
       }
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
     "stringifier": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/stringifier/-/stringifier-1.3.0.tgz",
@@ -3711,19 +3004,6 @@
         "core-js": "2.5.3",
         "traverse": "0.6.6",
         "type-name": "2.0.2"
-      }
-    },
-    "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
-    },
-    "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "requires": {
-        "ansi-regex": "2.1.1"
       }
     },
     "superagent": {
@@ -3795,11 +3075,6 @@
         "superagent": "3.8.2"
       }
     },
-    "supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-    },
     "symbol-observable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
@@ -3833,33 +3108,11 @@
         }
       }
     },
-    "tough-cookie": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
-      "requires": {
-        "punycode": "1.4.1"
-      }
-    },
     "traverse": {
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
       "dev": true
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "optional": true
     },
     "type-detect": {
       "version": "1.0.0",
@@ -3881,11 +3134,6 @@
       "resolved": "https://registry.npmjs.org/type-name/-/type-name-2.0.2.tgz",
       "integrity": "sha1-7+fUEj2KxSr/9/QMfk3sUmYAj7Q=",
       "dev": true
-    },
-    "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "underscore": {
       "version": "1.3.3",
@@ -3911,7 +3159,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -3928,16 +3177,6 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
-      }
-    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -3947,7 +3186,8 @@
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
     },
     "yallist": {
       "version": "2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,9 +73,9 @@
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "assertion-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
     "async": {
@@ -100,6 +100,15 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+    },
+    "axios": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
+      "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+      "requires": {
+        "follow-redirects": "1.4.1",
+        "is-buffer": "1.1.6"
+      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -230,15 +239,6 @@
       "integrity": "sha1-qEq8glpV70yysCi9dOIFpluaSZY=",
       "dev": true
     },
-    "caller-id": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/caller-id/-/caller-id-0.1.0.tgz",
-      "integrity": "sha1-Wb2sCJPRLDhxQIJ5Ix+XRYNk8Hs=",
-      "dev": true,
-      "requires": {
-        "stack-trace": "0.0.10"
-      }
-    },
     "camelcase": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
@@ -264,7 +264,7 @@
       "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
       "dev": true,
       "requires": {
-        "assertion-error": "1.0.2",
+        "assertion-error": "1.1.0",
         "deep-eql": "0.1.3",
         "type-detect": "1.0.0"
       }
@@ -879,6 +879,24 @@
         }
       }
     },
+    "follow-redirects": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.1.tgz",
+      "integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
+      "requires": {
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "foreach": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
@@ -935,6 +953,12 @@
         "is-property": "1.0.2"
       }
     },
+    "get-caller-file": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+      "dev": true
+    },
     "get-stdin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
@@ -962,46 +986,42 @@
         "path-is-absolute": "1.0.1"
       }
     },
-    "google-p12-pem": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-0.1.2.tgz",
-      "integrity": "sha1-M8RqsCGqc0+gMys5YKmj/8svMXc=",
+    "google-auth-library": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-1.1.0.tgz",
+      "integrity": "sha512-WgWLwplY8ftublrySvrJYsoJR0eL1TBqG3cxCPInYZmpo2h0aEpCYJBP0Lz43OO0ceMc7BreLghZXXVfrbF/PA==",
       "requires": {
-        "node-forge": "0.7.1"
-      }
-    },
-    "googleapis": {
-      "version": "22.2.0",
-      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-22.2.0.tgz",
-      "integrity": "sha1-/XnDwm5+caT1ouwafaX7EV2IU9I=",
-      "requires": {
-        "async": "2.3.0",
-        "google-auth-library": "0.10.0",
-        "string-template": "1.0.0"
+        "axios": "0.17.1",
+        "gtoken": "2.1.0",
+        "jws": "3.1.4",
+        "lodash.isstring": "4.0.1",
+        "lru-cache": "4.1.1"
       },
       "dependencies": {
-        "async": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.3.0.tgz",
-          "integrity": "sha1-EBPRBRBH3TIP4k5JTVxm7K9hR9k=",
-          "requires": {
-            "lodash": "4.17.4"
-          }
-        },
         "base64url": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
           "integrity": "sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs="
         },
-        "google-auth-library": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-0.10.0.tgz",
-          "integrity": "sha1-bhW6vuhf0d0U2NEoopW2g41SE24=",
+        "google-p12-pem": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-1.0.0.tgz",
+          "integrity": "sha512-tqu8IJF307iH8vXQEI5ZhuIk89vAf25rmoyoenckm/zY7Elzm4X/x6OPOk4wa3sRzkA/Y2CkubpvLxSEgIEQcg==",
           "requires": {
-            "gtoken": "1.2.3",
+            "node-forge": "0.7.1",
+            "pify": "3.0.0"
+          }
+        },
+        "gtoken": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-2.1.0.tgz",
+          "integrity": "sha512-r/dh/cVgPBWHcskq03KOSDl+L+0Ac0B8VEhpIbnrcsvHSJHdkEtwbC0lOZNxBIqWbM1+HNig8jpuCwKJzCcilg==",
+          "requires": {
+            "axios": "0.17.1",
+            "google-p12-pem": "1.0.0",
             "jws": "3.1.4",
-            "lodash.noop": "3.0.1",
-            "request": "2.83.0"
+            "mime": "2.2.0",
+            "pify": "3.0.0"
           }
         },
         "jwa": {
@@ -1023,6 +1043,41 @@
             "base64url": "2.0.0",
             "jwa": "1.1.5",
             "safe-buffer": "5.1.1"
+          }
+        },
+        "mime": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.2.0.tgz",
+          "integrity": "sha512-0Qz9uF1ATtl8RKJG4VRfOymh7PyEor6NbrI/61lRfuRe4vx9SNATrvAeTj2EWVRKjEQGskrzWkJBBY5NbaVHIA=="
+        }
+      }
+    },
+    "google-p12-pem": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-0.1.2.tgz",
+      "integrity": "sha1-M8RqsCGqc0+gMys5YKmj/8svMXc=",
+      "requires": {
+        "node-forge": "0.7.1"
+      }
+    },
+    "googleapis": {
+      "version": "25.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-25.0.0.tgz",
+      "integrity": "sha512-hIP2VbwFliL7YHZQRaJrw5+ctunALJUior4KEw0vCYlcDezPnEA+HhTY2oq4I3PCHBKxKwc9xfV37Kkz6e/krw==",
+      "requires": {
+        "async": "2.6.0",
+        "google-auth-library": "1.1.0",
+        "qs": "6.5.1",
+        "string-template": "1.0.0",
+        "uuid": "3.1.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "requires": {
+            "lodash": "4.17.4"
           }
         }
       }
@@ -1161,9 +1216,9 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "inquirer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-4.0.1.tgz",
-      "integrity": "sha512-HVU3eq/6DCt5Wkt46N6cooQBLlQy55UcmTGwMOe7XEmuxgdVjNxllS3pxrKDc8+OmNIbu+saotsCfH7m+IxHfg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.0.1.tgz",
+      "integrity": "sha512-si5Jmjj6ngjkDSPt/MwuIysUNNKu8SGWnweZE2QXRfd5SKJgDown8IDbHQiS5WLxqEQDQC0Vjcgtpw1XyZJWpw==",
       "requires": {
         "ansi-escapes": "3.0.0",
         "chalk": "2.3.0",
@@ -1174,8 +1229,7 @@
         "lodash": "4.17.4",
         "mute-stream": "0.0.7",
         "run-async": "2.3.0",
-        "rx-lite": "4.0.8",
-        "rx-lite-aggregates": "4.0.8",
+        "rxjs": "5.5.6",
         "string-width": "2.1.1",
         "strip-ansi": "4.0.0",
         "through": "2.3.8"
@@ -1227,6 +1281,11 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
       "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A="
     },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
     "is-finite": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
@@ -1272,9 +1331,9 @@
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "isemail": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.0.0.tgz",
-      "integrity": "sha512-rz0ng/c+fX+zACpLgDB8fnUQ845WSU06f4hlhk4K8TJxmR6f5hyvitu9a9JdMD7aq/P4E0XdG1uaab2OiXgHlA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.0.tgz",
+      "integrity": "sha512-Ke15MBbbhyIhZzWheiWuRlTO81tTH4RQvrbJFpVzJce8oyVrCVSDdrcw4TcyMsaS/fMGJSbU3lTsqCGDKwrzww==",
       "requires": {
         "punycode": "2.1.0"
       },
@@ -1292,12 +1351,12 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "joi": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-13.0.2.tgz",
-      "integrity": "sha512-kVka3LaHQyENvcMW4WJPSepGM43oCofcKxfs9HbbKd/FrwBAAt4lNNTPKOzSMmV53GIspmNO4U3O2TzoGvxxCA==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-13.1.1.tgz",
+      "integrity": "sha512-Y44bDwIoeCjFDRO18VaMRc0hIdPkLbZaF2VqU7t1tCcno3S3XzsmlYYpOu0Qk6nkzoI5RSao7W57NTvPKxbkcg==",
       "requires": {
         "hoek": "5.0.2",
-        "isemail": "3.0.0",
+        "isemail": "3.1.0",
         "topo": "3.0.0"
       },
       "dependencies": {
@@ -1389,10 +1448,24 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
     "lodash.noop": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-3.0.1.tgz",
       "integrity": "sha1-OBiPTWUKOkdCWEObluxFsyYXEzw="
+    },
+    "lru-cache": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
     },
     "map-obj": {
       "version": "1.0.1",
@@ -1480,9 +1553,9 @@
       }
     },
     "mocha": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
-      "integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.0.tgz",
+      "integrity": "sha512-ukB2dF+u4aeJjc6IGtPNnJXfeby5d4ZqySlIBT0OEyva/DrMjVm5HkQxKnHDLKEfEQBsEnwTg9HHhtPHJdTd8w==",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
@@ -1518,12 +1591,12 @@
       }
     },
     "mock-require": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/mock-require/-/mock-require-2.0.2.tgz",
-      "integrity": "sha1-HqpxqtIwE3c9En3H6Ro/u0g31g0=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mock-require/-/mock-require-3.0.1.tgz",
+      "integrity": "sha1-1e/YNMDaDOxzx7Z3Y9gWfTLYUd4=",
       "dev": true,
       "requires": {
-        "caller-id": "0.1.0"
+        "get-caller-file": "1.0.2"
       }
     },
     "morgan": {
@@ -1554,9 +1627,9 @@
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
     "nock": {
-      "version": "9.1.5",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-9.1.5.tgz",
-      "integrity": "sha512-ukkBUhGU73CmSKTpTl6N/Qjvb7Hev4rCEjgOuEBKvHmsOqz7jGh2vUXL3dPnX3ndfcmVjsFBPfKpNuJbK94SKg==",
+      "version": "9.1.6",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-9.1.6.tgz",
+      "integrity": "sha512-DuKF+1W/FnMO6MXIGgCIWcM95bETjBbmFdR4v7dAj1zH9a9XhOjAa//PuWh98XIXxcZt7wdiv0JlO0AA0e2kqQ==",
       "dev": true,
       "requires": {
         "chai": "3.5.0",
@@ -1567,7 +1640,7 @@
         "mkdirp": "0.5.1",
         "propagate": "0.4.0",
         "qs": "6.5.1",
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       }
     },
     "node-forge": {
@@ -3246,6 +3319,11 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
+    "pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+    },
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
@@ -3399,6 +3477,11 @@
         "ipaddr.js": "1.5.2"
       }
     },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -3490,17 +3573,12 @@
         "is-promise": "2.1.0"
       }
     },
-    "rx-lite": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
-    },
-    "rx-lite-aggregates": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
-      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+    "rxjs": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.6.tgz",
+      "integrity": "sha512-v4Q5HDC0FHAQ7zcBX7T2IL6O5ltl1a2GX4ENjPXg6SjDY69Cmx9v4113C99a4wGF16ClPv5Z8mghuYorVkg/kg==",
       "requires": {
-        "rx-lite": "4.0.8"
+        "symbol-observable": "1.0.1"
       }
     },
     "safe-buffer": {
@@ -3509,9 +3587,9 @@
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
       "dev": true
     },
     "send": {
@@ -3584,12 +3662,6 @@
         "jsbn": "0.1.1",
         "tweetnacl": "0.14.5"
       }
-    },
-    "stack-trace": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
-      "dev": true
     },
     "statuses": {
       "version": "1.4.0",
@@ -3727,6 +3799,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+    },
+    "symbol-observable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
     },
     "through": {
       "version": "2.3.8",
@@ -3871,6 +3948,11 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,16 +29,16 @@
     "crypto-random-string": "1.0.0",
     "drive-config": "^0.1.1",
     "express": "^4.15.3",
-    "googleapis": "22.2.0",
-    "inquirer": "4.0.1",
-    "joi": "13.0.2",
+    "googleapis": "25.0.0",
+    "inquirer": "5.0.1",
+    "joi": "13.1.1",
     "json-validation": "^1.0.4",
     "morgan": "1.9.0"
   },
   "devDependencies": {
-    "mocha": "4.0.1",
-    "mock-require": "2.0.2",
-    "nock": "9.1.5",
+    "mocha": "5.0.0",
+    "mock-require": "3.0.1",
+    "nock": "9.1.6",
     "nyc": "11.4.1",
     "power-assert": "1.4.4",
     "supertest": "3.0.0"

--- a/package.json
+++ b/package.json
@@ -22,12 +22,12 @@
   },
   "homepage": "https://github.com/lyrgard/ffbeEquip#readme",
   "dependencies": {
+    "@sindresorhus/is": "0.7.0",
     "bluebird": "3.5.1",
     "body-parser": "^1.17.2",
     "boom": "7.1.1",
     "client-sessions": "0.8.0",
     "crypto-random-string": "1.0.0",
-    "drive-config": "^0.1.1",
     "express": "^4.15.3",
     "googleapis": "25.0.0",
     "inquirer": "5.0.1",

--- a/server/lib/drive.js
+++ b/server/lib/drive.js
@@ -1,0 +1,107 @@
+const Promise = require('bluebird');
+const google = require('googleapis');
+const is = require('@sindresorhus/is');
+
+const drive = google.drive('v3');
+const mimeType = 'application/json';
+
+const create = (auth, fileName, data) => {
+  return Promise
+    .fromCallback(cb => drive.files.create({
+      resource: {
+        name: fileName,
+        parents: ['appDataFolder'],
+      },
+      media: {
+        mimeType,
+        body: JSON.stringify(data),
+      },
+      auth,
+    }, cb))
+    .then(res => res.data);
+};
+
+const list = (auth) => {
+  return Promise
+    .fromCallback(cb => drive.files.list({
+      q: `mimeType="${mimeType}"`,
+      spaces: 'appDataFolder',
+      auth,
+    }, cb))
+    .then(res => res.data.files);
+};
+
+const get = (auth, fileId) => {
+  return Promise
+    .fromCallback(cb => drive.files.get({
+      fileId,
+      alt: 'media',
+      auth,
+    }, cb))
+    .then(res => res.data);
+};
+
+const update = (auth, fileId, data) => {
+  return Promise
+    .fromCallback(cb => drive.files.update({
+      fileId,
+      media: {
+        mimeType,
+        body: JSON.stringify(data),
+      },
+      auth,
+    }, cb))
+    .then(res => res.data);
+};
+
+/**
+ * @summary Read a JSON file on gDrive
+ * @param {OAuht2} auth - OAuth2 Client
+ * @param {string} fileName
+ * @param {any} emptyValue
+ * @returns {Promise<any>}
+ */
+const readJson = async (auth, fileName, emptyValue) => {
+  const files = await list(auth);
+  if (files.length === 0) {
+    return emptyValue;
+  }
+
+  const file = files.find(item => item.name === fileName);
+  if (!file) {
+    return emptyValue;
+  }
+
+  const content = await get(auth, file.id);
+  if (is.string(content)) {
+    return JSON.parse(content);
+  }
+
+  return content;
+};
+
+/**
+ * @summary Write a JSON file on gDrive
+ * @param {OAuht2} auth - OAuth2 Client
+ * @param {string} fileName
+ * @param {any} data
+ * @returns {Promise<any>}
+ */
+const writeJson = async (auth, fileName, data) => {
+  const files = await list(auth);
+  if (files.length === 0) {
+    return create(auth, fileName, data);
+  }
+
+  const file = files.find(item => item.name === fileName);
+  if (!file) {
+    return create(auth, fileName, data);
+  }
+
+  return update(auth, file.id, data);
+};
+
+module.exports = {
+  readJson,
+  writeJson,
+};

--- a/server/lib/migration.js
+++ b/server/lib/migration.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+
+/* eslint import/no-dynamic-require: 0, global-require: 0 */
+const load = (schema) => {
+  const dir = path.join(__dirname, `../migrations/${schema}`);
+  let files;
+  try {
+    files = fs.readdirSync(dir);
+  } catch (err) {
+    files = [];
+  }
+  return files.sort().map(file => require(path.join(dir, file)));
+};
+
+const migrations = {};
+
+const up = (table, data) => {
+  if (!migrations[table]) {
+    migrations[table] = load(table);
+  }
+
+  return migrations[table].reduce((acc, migration) => {
+    return migration.up(acc);
+  }, data);
+};
+
+module.exports = {
+  up,
+};

--- a/server/lib/oauth.js
+++ b/server/lib/oauth.js
@@ -25,13 +25,17 @@ const createClient = (tokens) => {
 const client = createClient();
 const authUrl = client.generateAuthUrl({
   access_type: 'offline',
-  scope: [
-    'https://www.googleapis.com/auth/drive.appfolder',
-  ],
+  scope: ['https://www.googleapis.com/auth/drive.appfolder'],
+});
+const authUrlConsent = client.generateAuthUrl({
+  access_type: 'offline',
+  prompt: 'consent',
+  scope: ['https://www.googleapis.com/auth/drive.appfolder'],
 });
 
 module.exports = {
   authUrl,
+  authUrlConsent,
   client,
   createClient,
 };

--- a/server/lib/shortener.js
+++ b/server/lib/shortener.js
@@ -15,7 +15,7 @@ const urlshortener = google.urlshortener({
 const insert = (longUrl) => {
   return Promise
     .fromCallback(cb => urlshortener.url.insert({ resource: { longUrl } }, cb))
-    .then(res => res.id);
+    .then(res => res.data.id);
 };
 
 /**
@@ -26,7 +26,7 @@ const insert = (longUrl) => {
 const get = (shortUrl) => {
   return Promise
     .fromCallback(cb => urlshortener.url.get({ shortUrl }, cb))
-    .then(res => res.longUrl);
+    .then(res => res.data.longUrl);
 };
 
 module.exports = {

--- a/server/middlewares/oauth.js
+++ b/server/middlewares/oauth.js
@@ -7,5 +7,9 @@ module.exports = (req, res, next) => {
   }
 
   req.OAuth2Client = OAuth.createClient(tokens);
-  return next();
+
+  return req.OAuth2Client.getRequestMetadata(null, (error) => {
+    req.OAuthSession.tokens = req.OAuth2Client.credentials;
+    next(error);
+  });
 };

--- a/server/migrations/itemInventory/2_name_to_id.js
+++ b/server/migrations/itemInventory/2_name_to_id.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+
+const GLDataPath = path.join(__dirname, '../../../static/GL/data.json');
+const GLData = JSON.parse(fs.readFileSync(GLDataPath, 'utf8'));
+const GLDataByName = GLData.reduce((accumulator, current) => {
+  /* eslint no-param-reassign: 0 */
+  accumulator[current.name] = current.id;
+  return accumulator;
+}, {});
+
+GLDataByName['Blade Mastery'] = '504201670';
+GLDataByName['Zwill Crossblade'] = '1100000083';
+GLDataByName['Zwill Crossblade (FFT)'] = '301002000';
+GLDataByName['Imperial Helm (Item)'] = '404001100';
+GLDataByName['Defender (FFT)'] = '303002400';
+GLDataByName['Save the Queen'] = '303001400';
+
+module.exports.up = (inventory) => {
+  if (inventory.version >= 2) return inventory;
+
+  const newInventory = Object.keys(inventory).reduce((accumulator, current) => {
+    if (GLDataByName[current]) {
+      accumulator[GLDataByName[current]] = inventory[current];
+    } else {
+      accumulator[current] = inventory[current];
+    }
+    return accumulator;
+  }, {});
+
+  newInventory.version = 2;
+
+  return newInventory;
+};

--- a/server/migrations/itemInventory/3_agrias_tmr.js
+++ b/server/migrations/itemInventory/3_agrias_tmr.js
@@ -1,0 +1,13 @@
+module.exports.up = (inventory) => {
+  if (inventory.version >= 3) return inventory;
+
+  const newInventory = Object.assign({}, inventory);
+  if (inventory['303003500']) {
+    newInventory['303001400'] = inventory['303003500'];
+    delete newInventory['303003500'];
+  }
+
+  newInventory.version = 3;
+
+  return newInventory;
+};

--- a/server/routes/drive.js
+++ b/server/routes/drive.js
@@ -1,0 +1,33 @@
+const express = require('express');
+const drive = require('../lib/drive.js');
+const migration = require('../lib/migration.js');
+
+const DB_VERSION = 3;
+
+const route = express.Router();
+
+route.get('/:server/:table', async (req, res) => {
+  const { server, table } = req.params;
+  const auth = req.OAuth2Client;
+
+  let db = await drive.readJson(auth, `${table}_${server}.json`, {});
+  if (db.version !== DB_VERSION) {
+    db = migration.up(table, db);
+  }
+
+  return res.status(200).json(db);
+});
+
+route.put('/:server/:table', async (req, res) => {
+  const { server, table } = req.params;
+  const auth = req.OAuth2Client;
+
+  const data = req.body;
+  data.version = DB_VERSION;
+
+  await drive.writeJson(auth, `${table}_${server}.json`, data);
+
+  return res.status(200).json(data);
+});
+
+module.exports = route;

--- a/server/routes/oauth.js
+++ b/server/routes/oauth.js
@@ -25,7 +25,9 @@ route.get('/googleOAuthSuccess', validator.query(callbackSchema), (req, res, nex
 
   OAuth.client.getToken(code, (err, tokens) => {
     if (err) {
-      return next(Boom.boomify(err, { statusCode: err.code }));
+      return next(Boom.boomify(err, {
+        statusCode: err.code,
+      }));
     }
     req.OAuthSession.tokens = tokens;
     return res.redirect(state);

--- a/test/server/middlewares/test.oauth.js
+++ b/test/server/middlewares/test.oauth.js
@@ -7,6 +7,10 @@ const authRequired = require('../../../server/middlewares/oauth.js');
 describe('middlewares.oauth', () => {
   const app = express();
   const agent = request.agent(app);
+  const fixtureToken = {
+    access_token: 'TEST_TOKEN',
+    token_type: 'Bearer',
+  };
 
   // Middleware
   app.use(sessions({
@@ -20,7 +24,7 @@ describe('middlewares.oauth', () => {
     return res.status(200).send(tokens);
   });
   app.get('/authenticate', (req, res) => {
-    req.OAuthSession.tokens = 'test';
+    req.OAuthSession.tokens = fixtureToken;
     return res.status(200).send();
   });
 
@@ -42,6 +46,6 @@ describe('middlewares.oauth', () => {
   it('.authorized', (done) => {
     agent
       .get('/secure')
-      .expect(200, 'test', done);
+      .expect(200, JSON.stringify(fixtureToken), done);
   });
 });

--- a/test/server/utils.js
+++ b/test/server/utils.js
@@ -4,13 +4,13 @@ const mock = require('mock-require');
 const testConfig = {
   port: 3000,
   env: 'test',
-  secret: 'secret',
-  googleApiKey: 'test',
+  secret: 'test_secret',
+  googleApiKey: 'test_api_key',
   googleOAuthCredential: {
     web: {
-      client_id: 'test',
-      client_secret: 'test',
-      redirect_uris: ['http://localhost/test'],
+      client_id: 'test_client_id',
+      client_secret: 'test_client_secret',
+      redirect_uris: ['http://localhost/test-redirect-uri'],
     },
   },
   isDev: false,
@@ -27,9 +27,9 @@ module.exports.mockGoogleShortener = (longUrl, id) => {
     longUrl,
   });
   nock('https://www.googleapis.com')
-    .post('/urlshortener/v1/url', () => true).query(true)
+    .post('/urlshortener/v1/url', { longUrl }).query({ key: testConfig.googleApiKey })
     .reply(201, res);
   nock('https://www.googleapis.com')
-    .get('/urlshortener/v1/url').query(true)
+    .get('/urlshortener/v1/url').query({ shortUrl: id, key: testConfig.googleApiKey })
     .reply(200, res);
 };


### PR DESCRIPTION
Hi @lyrgard

Following on the previous PR, here is a refactoring of the gDrive routes.
I've added the necessary logic into the OAuth middleware to extend OAuth session time if possible by using the `refresh_token`.

Btw, do you still use `/:server/items/temp` route ?