### PR TITLE
Removes trailing whitelines in build as text

### DIFF
--- a/static/builder.js
+++ b/static/builder.js
@@ -1728,7 +1728,7 @@ function getItemLineAsText(prefix, slot) {
                 resultText += baseStats[statIndex].toUpperCase() + "+" + item[baseStats[statIndex]+"%"] + "%";
             }
         }
-        return resultText + "  \n";
+        return resultText + "\n";
     } else {
         return "";
     }


### PR DESCRIPTION
The whitespaces at the end of lines in the "Build as text" seem out of place, and they appear in copy/pasted builds. Would it be okay to remove them?