### PR TITLE
Fix for issue 6* builds linking to 7* unit

### DIFF
--- a/static/builder.js
+++ b/static/builder.js
@@ -765,6 +765,7 @@ function onUnitChange() {
         var selectedUnitData;
         if (unitId.endsWith("-6")) {
             selectedUnitData = units[unitId.substr(0,unitId.length-2)]["6_form"];
+            selectedUnitData.sixstarForm = true;
         } else {
             selectedUnitData = units[unitId];    
         }
@@ -906,7 +907,7 @@ function loadBuild(buildIndex) {
     
     $("#unitsSelect option").prop("selected", false);
     if (build.unit) {
-        $('#unitsSelect option[value="' + build.unit.id + '"]').prop("selected", true);
+        $('#unitsSelect option[value="' + build.unit.id + (build.unit.sixstarForm ? '-6' : '') + '"]').prop("selected", true);
     }
     $("#unitsSelect").combobox("refresh");
     $(".unitAttackElement div.elements label").removeClass("active");
@@ -1799,7 +1800,7 @@ function loadStateHashAndBuild(data) {
         }
         $("#unitsSelect").combobox("refresh");
         onUnitChange();
-        
+
         if (unit.enhancementLevels) {
             builds[currentUnitIndex].unit.enhancementLevels = unit.enhancementLevels;
             displayUnitEnhancements();


### PR DESCRIPTION
Fix for https://github.com/lyrgard/ffbeEquip/issues/103

I think there could be some rework in the amount of onUnitChange refreshes, and that the sixstarForm could actually be reflected in the unit data, instead of having to be marshalled. However, this is a super-fast fix that's not too hacky.

It introduces a sixstarForm variable to the unit in onUnitChange (line 768) that is later used to build the correct ID in loadBuild (which earlier just used raw unit.id which did not carry 6* form information)