### PR TITLE
Added possibility to exclude items in search results

### DIFF
--- a/static/builder.html
+++ b/static/builder.html
@@ -374,6 +374,7 @@
                         <div class="checkboxGroup"><input id="excludeTMR5" type="checkbox"/><label>Exclude TMR of base 5* units</label></div>
                         <div class="checkboxGroup" data-server="JP"><input id="excludeSTMR" type="checkbox"/><label>Exclude STMR</label></div>
                         <div class="checkboxGroup"><input id="excludeNotReleasedYet" type="checkbox" checked="true"><label>Exclude not released yet equipments</label></div>
+                        <div><a class="link" onclick="displayEquippableItemList();">Select items to exclude</a></div>
                         <div><a class="link" onclick="showExcludedItems();"><span class="excludedItemNumber"></span> specifically excluded item(s)</a></div>
                     </div>
                 </div>

--- a/static/builder.html
+++ b/static/builder.html
@@ -374,7 +374,7 @@
                         <div class="checkboxGroup"><input id="excludeTMR5" type="checkbox"/><label>Exclude TMR of base 5* units</label></div>
                         <div class="checkboxGroup" data-server="JP"><input id="excludeSTMR" type="checkbox"/><label>Exclude STMR</label></div>
                         <div class="checkboxGroup"><input id="excludeNotReleasedYet" type="checkbox" checked="true"><label>Exclude not released yet equipments</label></div>
-                        <div><a class="link" onclick="displayEquippableItemList();">Select items to exclude</a></div>
+                        <div><a class="link" onclick="displayEquipableItemList();">Select items to exclude</a></div>
                         <div><a class="link" onclick="showExcludedItems();"><span class="excludedItemNumber"></span> specifically excluded item(s)</a></div>
                     </div>
                 </div>

--- a/static/builder.js
+++ b/static/builder.js
@@ -1123,9 +1123,7 @@ function onEquipmentsChange() {
     updateEspers();
 }
      
-function updateSearchResult(clickBehavior = ClickBehaviors.EQUIP) {
-    selectSearchClickBehavior(clickBehavior);
-
+function updateSearchResult() {
     $("#fixItemModal").removeClass("showEnhancements");
     var searchText = $("#searchText").val();
     if ((searchText == null || searchText == "") && searchType.length == 0 && searchStat == "") {
@@ -1231,7 +1229,8 @@ function displayEquipableItemList() {
     populateItemType(types);
     selectSearchType(types);
     selectSearchStat(searchStat);
-    updateSearchResult(ClickBehaviors.EXCLUDE);
+    selectSearchClickBehavior(ClickBehaviors.EXCLUDE);
+    updateSearchResult();
 }
 
 function displayFixItemModal(index) {
@@ -1256,6 +1255,7 @@ function displayFixItemModal(index) {
     $("#fixItemModal").modal();
     selectSearchStat(searchStat);
     selectSearchType(builds[currentUnitIndex].equipable[index]);
+    selectSearchClickBehavior(ClickBehaviors.EQUIP);
     updateSearchResult();
 }
 
@@ -1509,12 +1509,12 @@ function displaySearchResultsAsync(items, start, div) {
             
             var excluded = itemsToExclude.includes(item.id);
 
-            if(searchClickBehavior == ClickBehaviors.EQUIP) {
-                html += '" onclick="fixItem(\'' + item.id + '\', ' + currentItemSlot + ', ' + enhancementString + ')">';
+            if(searchClickBehavior == ClickBehaviors.IGNORE) {
+                html += '" >';
             } else if (searchClickBehavior == ClickBehaviors.EXCLUDE) {
                 html += '" onclick="toggleExclusionFromSearch(\'' + item.id + '\');">';
             } else {
-                html += '" >';
+                html += '" onclick="fixItem(\'' + item.id + '\', ' + currentItemSlot + ', ' + enhancementString + ')">';
             }
 
             html += "<div class='td exclude'>";

--- a/static/builder.js
+++ b/static/builder.js
@@ -1517,7 +1517,11 @@ function displaySearchResultsAsync(items, start, div) {
                 html += '" >';
             }
 
-            html += displayItemLine(item, excluded ? ExclusionDisplayType.EXCLUDED : ExclusionDisplayType.INCLUDED);
+            html += "<div class='td exclude'>";
+            html += getItemExclusionLink(item.id, excluded);
+            html += "</div>";
+
+            html += displayItemLine(item);
             
             if (searchClickBehavior != ClickBehaviors.EXCLUDE) {
                 html+= "<div class='td enchantment desktop'>";
@@ -1574,12 +1578,10 @@ function getItemEnhancementLink(item) {
     return html;
 }
 
-function getItemExclusionLink(item, excluded) {
+function getItemExclusionLink(itemId, excluded) {
     var html = "";
-
-    html += '<span title="Exclude this item from builds" class="excludeItem glyphicon glyphicon-ban-circle itemid' + item.id + '" style="color:red;' + (excluded ? 'display: none;' : '') + '" onclick="event.stopPropagation(); excludeItem(\'' + item.id + '\'); toggleExclusionIcon(\'' + item.id + '\');"></span>';
-    html += '<span title="Include this item in builds again" class="excludeItem glyphicon glyphicon-ok-circle itemid' + item.id + '" style="color:green;' + (!excluded ? 'display: none;' : '') + '" onclick="event.stopPropagation(); removeItemFromExcludeList(\'' + item.id + '\'); toggleExclusionIcon(\'' + item.id + '\');"></span>';
-
+    html += '<span title="Exclude this item from builds" class="miniIcon left excludeItem glyphicon glyphicon-ban-circle false itemid' + itemId + '" style="' + (excluded ? 'display: none;' : '') + '" onclick="event.stopPropagation(); toggleExclusionFromSearch(\'' + itemId + '\');"></span>';
+    html += '<span title="Include this item in builds again" class="miniIcon left excludeItem glyphicon glyphicon-ban-circle true itemid' + itemId + '" style="' + (!excluded ? 'display: none;' : '') + '" onclick="event.stopPropagation(); toggleExclusionFromSearch(\'' + itemId + '\');"></span>';
     return html;
 }
 

--- a/static/builder.js
+++ b/static/builder.js
@@ -45,7 +45,8 @@ var searchType = [];
 var searchStat = "";
 var ClickBehaviors = {
     EQUIP: 0,
-    IGNORE: 1
+    IGNORE: 1,
+    EXCLUDE: 2
 };
 var searchClickBehavior = ClickBehaviors.EQUIP;
 var currentItemSlot;
@@ -1200,7 +1201,7 @@ function updateSearchResult(clickBehavior = ClickBehaviors.EQUIP) {
     });
 }
 
-function displayEquippableItemList() {
+function displayEquipableItemList() {
     if (!builds[currentUnitIndex].unit) {
         alert("Please select an unit");
         return;
@@ -1230,7 +1231,7 @@ function displayEquippableItemList() {
     populateItemType(types);
     selectSearchType(types);
     selectSearchStat(searchStat);
-    updateSearchResult(ClickBehaviors.IGNORE);
+    updateSearchResult(ClickBehaviors.EXCLUDE);
 }
 
 function displayFixItemModal(index) {
@@ -1481,6 +1482,16 @@ var displaySearchResults = function(items) {
     
 }
 
+function toggleExclusionFromSearch(itemId) {
+    if(itemsToExclude.includes(itemId)) {
+        removeItemFromExcludeList(itemId);
+    } else {
+        excludeItem(itemId);
+    }
+    
+    toggleExclusionIcon(itemId);
+}
+
 function displaySearchResultsAsync(items, start, div) {
     var end = Math.max(items.length, start + 20);
     var html = "";
@@ -1496,18 +1507,24 @@ function displaySearchResultsAsync(items, start, div) {
                 html += " enhanced";
             }
             
+            var excluded = itemsToExclude.includes(item.id);
+
             if(searchClickBehavior == ClickBehaviors.EQUIP) {
                 html += '" onclick="fixItem(\'' + item.id + '\', ' + currentItemSlot + ', ' + enhancementString + ')">';
+            } else if (searchClickBehavior == ClickBehaviors.EXCLUDE) {
+                html += '" onclick="toggleExclusionFromSearch(\'' + item.id + '\');">';
             } else {
                 html += '" >';
             }
 
-            var excluded = itemsToExclude.includes(item.id);
-
             html += displayItemLine(item, excluded ? ExclusionDisplayType.EXCLUDED : ExclusionDisplayType.INCLUDED);
-            html+= "<div class='td enchantment desktop'>";
-            html+= getItemEnhancementLink(item);
-            html+= "</div>";
+            
+            if (searchClickBehavior != ClickBehaviors.EXCLUDE) {
+                html+= "<div class='td enchantment desktop'>";
+                html+= getItemEnhancementLink(item);
+                html+= "</div>";
+            }
+
             if (itemInventory) {
                 var notEnoughClass = "";
                 var numbers = dataStorage.getOwnedNumber(item);
@@ -1526,8 +1543,8 @@ function displaySearchResultsAsync(items, start, div) {
                 html+= '<div class="td mobile" onclick="event.stopPropagation();"><div class="menu">';
                 html+=      '<span class="dropdown-toggle glyphicon glyphicon-option-vertical" data-toggle="dropdown" onclick="$(this).parent().toggleClass(\'open\');"></span>'
                 html+=      '<ul class="dropdown-menu pull-right">';
-                html+=          '<li>' + getAccessHtml(item) + '</li>';
-                html+=          '<li>' + getItemEnhancementLink(item) + '</li>';
+                html+=          '<li>' + getAccessHtml(item) + '</li>';               
+                html+=          '<li>' + getItemEnhancementLink(item) + '</li>';                
                 html+=          '<li class="inventory"><span class="badge' + notEnoughClass + '">' + owned + '</span></li>';
                 html+=      '</ul>';
                 html+= '</div></div>';

--- a/static/common.css
+++ b/static/common.css
@@ -151,6 +151,23 @@ ul {
     margin-top: 30px;
     margin-left: 5px;
 }
+.miniIcon.left.excludeItem {
+    position: relative;
+    display: inline;
+    color:grey;
+    opacity: 0.5;
+}
+.miniIcon.left.excludeItem.true {
+    color: red;
+    opacity: 1.0;
+}
+.miniIcon.left.excludeItem.true:hover {
+    color: red;
+    opacity: 0.7;
+}
+.miniIcon.left.excludeItem.false:hover {
+    opacity: 1.0;
+}
 .miniIcon.topRight {
     margin-left: 55px;
     margin-top: 55px;

--- a/static/common.js
+++ b/static/common.js
@@ -36,8 +36,8 @@ function getImageHtml(item, exclusionDisplayType = ExclusionDisplayType.NONE) {
 
     if(exclusionDisplayType != ExclusionDisplayType.NONE) {
         var excluded = exclusionDisplayType == ExclusionDisplayType.EXCLUDED;
-        html += '<span title="Exclude this item from builds" class="miniIcon left excludeItem glyphicon glyphicon-ban-circle false itemid' + item.id + '" style="' + (excluded ? 'display: none;' : '') + '" onclick="event.stopPropagation(); excludeItem(\'' + item.id + '\'); toggleExclusionIcon(\'' + item.id + '\');"></span>';
-        html += '<span title="Include this item in builds again" class="miniIcon left excludeItem glyphicon glyphicon-ban-circle true itemid' + item.id + '" style="' + (!excluded ? 'display: none;' : '') + '" onclick="event.stopPropagation(); removeItemFromExcludeList(\'' + item.id + '\'); toggleExclusionIcon(\'' + item.id + '\');"></span>';
+        html += '<span title="Exclude this item from builds" class="miniIcon left excludeItem glyphicon glyphicon-ban-circle false itemid' + item.id + '" style="' + (excluded ? 'display: none;' : '') + '" onclick="event.stopPropagation(); toggleExclusionFromSearch(\'' + item.id + '\');"></span>';
+        html += '<span title="Include this item in builds again" class="miniIcon left excludeItem glyphicon glyphicon-ban-circle true itemid' + item.id + '" style="' + (!excluded ? 'display: none;' : '') + '" onclick="event.stopPropagation(); toggleExclusionFromSearch(\'' + item.id + '\');"></span>';
     }
 
     if (item.special && item.special.includes("notStackable")) {

--- a/static/common.js
+++ b/static/common.js
@@ -25,20 +25,8 @@ var mustSaveInventory = false;
 var mustSaveEspers = false;
 var userSettings;
 
-var ExclusionDisplayType = {
-    NONE: 0,
-    EXCLUDED: 1,
-    INCLUDED: 2
-};
-
-function getImageHtml(item, exclusionDisplayType = ExclusionDisplayType.NONE) {
+function getImageHtml(item) {
     var html = '<div class="td type">';
-
-    if(exclusionDisplayType != ExclusionDisplayType.NONE) {
-        var excluded = exclusionDisplayType == ExclusionDisplayType.EXCLUDED;
-        html += '<span title="Exclude this item from builds" class="miniIcon left excludeItem glyphicon glyphicon-ban-circle false itemid' + item.id + '" style="' + (excluded ? 'display: none;' : '') + '" onclick="event.stopPropagation(); toggleExclusionFromSearch(\'' + item.id + '\');"></span>';
-        html += '<span title="Include this item in builds again" class="miniIcon left excludeItem glyphicon glyphicon-ban-circle true itemid' + item.id + '" style="' + (!excluded ? 'display: none;' : '') + '" onclick="event.stopPropagation(); toggleExclusionFromSearch(\'' + item.id + '\');"></span>';
-    }
 
     if (item.special && item.special.includes("notStackable")) {
         html += "<img class='miniIcon left' src='img/notStackable.png' title='Not stackable'>";
@@ -252,10 +240,10 @@ function getEquipedConditionHtml(item) {
     return "<div class='exclusive'>If equiped with " + conditions + "</div>";
 }
 
-function displayItemLine(item, exclusionDisplayType = ExclusionDisplayType.NONE) {
+function displayItemLine(item) {
     html = "";
     // type
-    html += getImageHtml(item, exclusionDisplayType);
+    html += getImageHtml(item);
 
     // name
     html += getNameColumnHtml(item);

--- a/static/common.js
+++ b/static/common.js
@@ -25,8 +25,21 @@ var mustSaveInventory = false;
 var mustSaveEspers = false;
 var userSettings;
 
-function getImageHtml(item) {
+var ExclusionDisplayType = {
+    NONE: 0,
+    EXCLUDED: 1,
+    INCLUDED: 2
+};
+
+function getImageHtml(item, exclusionDisplayType = ExclusionDisplayType.NONE) {
     var html = '<div class="td type">';
+
+    if(exclusionDisplayType != ExclusionDisplayType.NONE) {
+        var excluded = exclusionDisplayType == ExclusionDisplayType.EXCLUDED;
+        html += '<span title="Exclude this item from builds" class="miniIcon left excludeItem glyphicon glyphicon-ban-circle false itemid' + item.id + '" style="' + (excluded ? 'display: none;' : '') + '" onclick="event.stopPropagation(); excludeItem(\'' + item.id + '\'); toggleExclusionIcon(\'' + item.id + '\');"></span>';
+        html += '<span title="Include this item in builds again" class="miniIcon left excludeItem glyphicon glyphicon-ban-circle true itemid' + item.id + '" style="' + (!excluded ? 'display: none;' : '') + '" onclick="event.stopPropagation(); removeItemFromExcludeList(\'' + item.id + '\'); toggleExclusionIcon(\'' + item.id + '\');"></span>';
+    }
+
     if (item.special && item.special.includes("notStackable")) {
         html += "<img class='miniIcon left' src='img/notStackable.png' title='Not stackable'>";
     }
@@ -239,10 +252,10 @@ function getEquipedConditionHtml(item) {
     return "<div class='exclusive'>If equiped with " + conditions + "</div>";
 }
 
-function displayItemLine(item) {
+function displayItemLine(item, exclusionDisplayType = ExclusionDisplayType.NONE) {
     html = "";
     // type
-    html += getImageHtml(item);
+    html += getImageHtml(item, exclusionDisplayType);
 
     // name
     html += getNameColumnHtml(item);


### PR DESCRIPTION
One thing that bothered me a bit is the disconnection between common.js and builder.js. Specifically for displaying an item row. It's a bit awkward as now the excluded state has to be passed onto common.js, that should technically not have to know about it.