### PR TITLE
Add wiki links for units and TMRs

### DIFF
--- a/static/units.js
+++ b/static/units.js
@@ -316,9 +316,9 @@ function getUnitDisplay(unit, useTmrName = false) {
         html += '<div class="unitImageWrapper"><div><img class="unitImage" src="/img/units/unit_ills_' + unit.id.substr(0, unit.id.length - 1) + formToDisplay + '.png"/></div></div>';
         html +='<div class="unitName">';
         if (useTmrName) {
-            html += tmrNameByUnitId[unit.id];
+            html += toLink(tmrNameByUnitId[unit.id]);
         } else {
-            html += unit.name;
+            html += toLink(unit.name);
         }
         html += '</div>';
         html += '<div class="unitRarity">'


### PR DESCRIPTION
Hello

This is my first attempts to implements #122

I noticed that the relevant function is already here (`toLink()`).
We just need to call it for the unit's name (and TMR's).

I couldn't test it locally as I didn't complete the OAUTH config yet...
I wish there would be a way to try the server without the state save feature...

I think it should be fine, except maybe for units with looong name, e.g.  `Atoning Dragoon Kain` or `Heavenly Technician Lid`...