### PR TITLE
Fix editor config tab size

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@ root = true
 
 [*]
 indent_style = space
-indent_size = 2
+indent_size = 4
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true


### PR DESCRIPTION
In the `.editorconfig` file, the indent size is set to 2.

I have nothing against it. However, most of the file are indented using 4 spaces...

Examples: `units.js` or `main.js`