### PR TITLE
Units: add rarity jump list

### DIFF
--- a/static/units.css
+++ b/static/units.css
@@ -123,6 +123,44 @@
     margin-top: 30px;
 }
 
+.rarityJumpList {
+    margin-top: 20px;
+    font-size: 0.9em;
+
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+}
+
+.rarityJumpList > span {
+    color: #808080;
+}
+
+.rarityJumpList > span,
+.rarityJumpList > a {
+    margin: 5px 0;
+}
+
+.rarityJumpList .rarityJump {
+    margin-left: 10px;
+    padding: 4px 6px;
+    border: 1px solid #c8c8c8;
+    background: #f7f7f7;
+    border-radius: 4px;
+    white-space: nowrap;
+}
+
+.rarityJumpList .rarityJump:hover {
+    border: 1px solid #808080;
+    background: #f0f0f0;
+}
+
+.rarityJumpList .rarityJump img {
+    width: 12px;
+    height: 12px;
+}
+
 .numberDiv {
     position: absolute;
     top: 40px;

--- a/static/units.js
+++ b/static/units.js
@@ -219,25 +219,33 @@ var displayUnits = function(units, useTmrName = false) {
 
 };
 
+function buildRarityID(min_rarity, max_rarity)
+{
+    return "rarity-" + min_rarity + "-of-" + max_rarity;
+}
+
 function displayUnitsByRarity(units, minRarity = 1) {
     var lastMinRarity, lastMaxRarity;
     var first = true;
 
     var html = '';
+    var rarity_list = []; // will gather rarity to display a jump list later
     for (var index = 0, len = units.length; index < len; index++) {
         var unit = units[index];
         if (unit.min_rarity < minRarity) {
             continue;
         }
         if (first) {
-            html += '<div class="raritySeparator">' + getRarity(unit.min_rarity, unit.max_rarity) + "</div>";
+            html += '<div class="raritySeparator" id="' + buildRarityID(unit.min_rarity, unit.max_rarity) + '">' + getRarity(unit.min_rarity, unit.max_rarity) + "</div>";
             html += '<div class="unitList">';
             first = false;
+            rarity_list.push(unit);
         } else {
             if (unit.max_rarity != lastMaxRarity || unit.min_rarity != lastMinRarity) {
                 html += '</div>';
-                html += '<div class="raritySeparator">' + getRarity(unit.min_rarity, unit.max_rarity) + "</div>";
+                html += '<div class="raritySeparator" id="' + buildRarityID(unit.min_rarity, unit.max_rarity) + '">' + getRarity(unit.min_rarity, unit.max_rarity) + "</div>";
                 html += '<div class="unitList">';
+                rarity_list.push(unit);
             }
         }
         lastMaxRarity = unit.max_rarity;
@@ -245,7 +253,20 @@ function displayUnitsByRarity(units, minRarity = 1) {
         html += getUnitDisplay(unit);
     }
     html += '</div>';
-    return html;
+    
+    // Jump list display
+    rarity_jump_html = '<div class="rarityJumpList">';
+    rarity_jump_html += '<span>Jump to </span>';
+    // Loop from end to begin, to show smaller star first
+    // Also, do not show index 0 because it's the one just below, so don't need to jump...
+    for (index = rarity_list.length - 1; index > 0; index--) {
+        rarity_jump_html += '<a class="rarityJump" href="#' + buildRarityID(rarity_list[index].min_rarity, rarity_list[index].max_rarity) + '">';
+        rarity_jump_html += getRarity(rarity_list[index].min_rarity, rarity_list[index].max_rarity) ;
+        rarity_jump_html += "</a>";
+    }
+    rarity_jump_html += '</div>';
+
+    return rarity_jump_html + html;
 
 };
 

--- a/static/units.js
+++ b/static/units.js
@@ -255,7 +255,7 @@ function displayUnitsByRarity(units, minRarity = 1) {
     html += '</div>';
     
     // Jump list display
-    rarity_jump_html = '<div class="rarityJumpList">';
+    rarity_jump_html = '<div class="rarityJumpList" data-html2canvas-ignore>';
     rarity_jump_html += '<span>Jump to </span>';
     // Loop from end to begin, to show smaller star first
     // Also, do not show index 0 because it's the one just below, so don't need to jump...


### PR DESCRIPTION
Hello,

Here I am, with another little QoL change!

A rarity jump list is added at the beginning of the unit list.
I simply use anchor to jump to the rarity.

Here what it looks like:
![image](https://user-images.githubusercontent.com/7137528/43784933-944a6ee6-9a65-11e8-85d1-d764a2a1656b.png)

Of course, it's flexible 😉 

![image](https://user-images.githubusercontent.com/7137528/43784968-a6192dd8-9a65-11e8-8dd6-a8bc01c5383c.png)
