### PR TITLE
Inventory: show equipments by types

### DIFF
--- a/static/common.js
+++ b/static/common.js
@@ -35,14 +35,15 @@ function getImageHtml(item) {
         html += "<img class='miniIcon left' src='img/twoHanded.png' title='Two-handed'>";
     }
     if (item.icon) {
-        html += "<img src='img/items/" + item.icon + "' class='icon'></img></div>";
+        html += "<img src='img/items/" + item.icon + "' class='icon'></img>";
     } else if (item.type == "esper") {
-        html += "<img src='img/" + escapeName(item.name) + ".png' class='icon'></img></div>";
+        html += "<img src='img/" + escapeName(item.name) + ".png' class='icon'></img>";
     } else if (item.type == "unavailable") {
         // no image
     } else {
-        html += "<img src='img/" + item.type + ".png' class='icon'></img></div>";
+        html += "<img src='img/" + item.type + ".png' class='icon'></img>";
     }
+    html += "</div>";
     return html;
 }
 
@@ -79,9 +80,9 @@ function getNameColumnHtml(item) {
     if (item.type != "esper" && item.type != "monster") {
         html += "<img src='img/" + item.type + ".png' class='miniIcon'></img>";
     }
-    html += getStatDetail(item) + "</div>"
+    html += getStatDetail(item) + "</div>";
     if (item.userPseudo) {
-        html += "<div class='userPseudo'>item added by " + item.userPseudo + "</div>"
+        html += "<div class='userPseudo'>item added by " + item.userPseudo + "</div>";
     }
     
     if (item.enhancements) {

--- a/static/inventory.css
+++ b/static/inventory.css
@@ -154,6 +154,17 @@
     display: block;
 }
 
+.itemList {
+    overflow: hidden;
+}
+
+.itemSeparator {
+    clear: both;
+    overflow: hidden;
+    margin: 30px 0 15px 0;
+    text-align: center;
+}
+
 @media (max-width: 991px) {
     .farmable .farmedButton {
         display: block;

--- a/static/inventory.css
+++ b/static/inventory.css
@@ -165,6 +165,47 @@
     text-align: center;
 }
 
+.typeJumpList {
+    margin: 20px auto 0 auto;
+    padding: 0 10px;
+    max-width: 70%;
+    font-size: 0.9em;
+    clear: both;
+
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+}
+
+.typeJumpList > span {
+    color: #808080;
+}
+
+.typeJumpList > span,
+.typeJumpList > a {
+    margin: 4px 0;
+}
+
+.typeJumpList .typeJump {
+    margin-left: 8px;
+    padding: 5px;
+    border: 1px solid #c8c8c8;
+    background: #f7f7f7;
+    border-radius: 4px;
+    white-space: nowrap;
+}
+
+.typeJumpList .typeJump:hover {
+    border: 1px solid #808080;
+    background: #f0f0f0;
+}
+
+.typeJumpList .typeJump img {
+    width: 18px;
+    height: 18px;
+}
+
 @media (max-width: 991px) {
     .farmable .farmedButton {
         display: block;

--- a/static/inventory.js
+++ b/static/inventory.js
@@ -122,15 +122,28 @@ var displayItems = function(items, byType = false) {
     var resultDiv = $("#results");
     resultDiv.empty();
     displayId++;
-    if (byType) displayItemsByTypeAsync(items, 0, resultDiv, displayId);
-    else displayItemsAsync(items, 0, resultDiv, displayId);
+    if (byType) {
+        // Jump list display
+        htmlTypeJump = '<div class="typeJumpList" data-html2canvas-ignore>';
+        htmlTypeJump += '<span>Jump to </span>';
+        htmlTypeJump += '</div>';
+        resultDiv.append(htmlTypeJump);
+
+        displayItemsByTypeAsync(items, 0, resultDiv, displayId, resultDiv.find('.typeJumpList'));
+    } else {
+        displayItemsAsync(items, 0, resultDiv, displayId);
+    }
 };
 
-function displayItemsByTypeAsync(items, start, div, id) {
-    // Set item type for this run
+function displayItemsByTypeAsync(items, start, div, id, jumpDiv) {
+    // Set item type for this run and various useful vars
     var currentItemType = items[start].type;
+    var currentItemTypeImgHtml = '<img src="img/' + currentItemType + '.png"/>';
+    var currentItemTypeAnchor = 'itemType' + currentItemType;
 
-    var html = '<div class="itemSeparator"><img src="img/' + currentItemType + '.png"/></div>';
+    var htmlTypeJump = '<a class="typeJump" href="#' + currentItemTypeAnchor + '">' + currentItemTypeImgHtml + '</a>';
+
+    var html = '<div class="itemSeparator" id="' + currentItemTypeAnchor + '">' + currentItemTypeImgHtml + '</div>';
     html += '<div class="itemList">';
     for (var index = start, len = items.length; index < len; index++) {
         var item = items[index];
@@ -144,10 +157,12 @@ function displayItemsByTypeAsync(items, start, div, id) {
     html += '</div>';
 
     if (id == displayId) {
+        // Add the jump and the all items to the DOM
+        jumpDiv.append(htmlTypeJump);
         div.append(html);
         if (index < items.length) {
             // Launch next run of type
-            setTimeout(displayItemsByTypeAsync, 0, items, index, div, id);
+            setTimeout(displayItemsByTypeAsync, 0, items, index, div, id, jumpDiv);
         }
     }
 };

--- a/static/inventory.js
+++ b/static/inventory.js
@@ -126,9 +126,9 @@ var displayItems = function(items, byType = false) {
     else displayItemsAsync(items, 0, resultDiv, displayId);
 };
 
-function displayItemsByTypeAsync(items, start, div, id, currentItemType = null) {
-    // Set first item type
-    if (!currentItemType) currentItemType = items[0].type;
+function displayItemsByTypeAsync(items, start, div, id) {
+    // Set item type for this run
+    var currentItemType = items[start].type;
 
     var html = '<div class="itemSeparator"><img src="img/' + currentItemType + '.png"/></div>';
     html += '<div class="itemList">';
@@ -138,7 +138,6 @@ function displayItemsByTypeAsync(items, start, div, id, currentItemType = null) 
         if (item.type === currentItemType) {
             html += getItemDisplay(item);
         } else {
-            currentItemType = item.type;
             break;
         }
     }
@@ -147,7 +146,8 @@ function displayItemsByTypeAsync(items, start, div, id, currentItemType = null) 
     if (id == displayId) {
         div.append(html);
         if (index < items.length) {
-            setTimeout(displayItemsByTypeAsync, 0, items, index, div, id, currentItemType);
+            // Launch next run of type
+            setTimeout(displayItemsByTypeAsync, 0, items, index, div, id);
         }
     }
 };


### PR DESCRIPTION
Hello again!


To be more similar to units page, here is a PR to **present equipments by types**:


![image](https://user-images.githubusercontent.com/7137528/43789891-6438b8dc-9a71-11e8-9a8f-fd04dbbb440b.png)


...


![image](https://user-images.githubusercontent.com/7137528/43789913-6fb31e00-9a71-11e8-8213-9562e765d885.png)


No name are shown, since there is, for now, no equivalent between internal type (e.g. `greatSword`) and full type name (e.g. `Great Sword`). Also it would have to be translated and all. So to keep it simple, only picture type is shown.

The async aspect was kept, but with types, the equipments are loaded by batch of same type (instead of batch of 20).

The materia listing is not modified, as the data currently doesn't allow us to discriminate between them (they all have `materia` as type). It would have been cool to sort by type as well (active, passive, etc...) like in game.