### PR TITLE
Add noreferrer for external link with _blank

### DIFF
--- a/static/builder.html
+++ b/static/builder.html
@@ -132,7 +132,7 @@
                                 <div class="unit-rarity">
 
                                 </div>
-                                <a id="unitLink" class="hidden" target="_blank">Unit info</a>
+                                <a id="unitLink" class="hidden" target="_blank" rel="noreferrer">Unit info</a>
                             </div>
                         </form>
                     </div>
@@ -480,7 +480,7 @@
                                             <li><a class="buildLink link" onclick="showBuildLink(true)"><span class="glyphicon glyphicon-link"></span> FFBE Equip link (this unit only)</a></li>
                                             <li><a class="buildLink link" onclick="showBuildLink(false)"><span class="glyphicon glyphicon-link"></span> FFBE Equip link (all units)</a></li>
                                             <li><a class="buildAsText link" onclick="showBuildAsText()"><span class="glyphicon glyphicon-list"></span> Build as text</a></li>
-                                            <li data-server="GL"><a class="imageLink link" target="_blank"><span class="glyphicon glyphicon-camera"></span> Build image (using kupoconfig.com)</a></li>
+                                            <li data-server="GL"><a class="imageLink link" target="_blank" rel="noreferrer"><span class="glyphicon glyphicon-camera"></span> Build image (using kupoconfig.com)</a></li>
                                         </ul>
                                     </div>
                                 </div>
@@ -592,16 +592,17 @@
                 </div>
                 <div class="footerButtons">
                     <div>
-                        <a class="buttonLink" href="https://www.reddit.com/message/compose/?to=lyrgard" target="_blank">Send me a message on reddit</a><a class="buttonLink" href="https://discord.gg/rgXnjhP" target="_blank">chat on FFBE Equip discord server</a>
+                        <a class="buttonLink" href="https://www.reddit.com/message/compose/?to=lyrgard" target="_blank" rel="noreferrer">Send me a message on reddit</a>
+                        <a class="buttonLink" href="https://discord.gg/rgXnjhP" target="_blank" rel="noreferrer">chat on FFBE Equip discord server</a>
                     </div>
                     <div>
-                        <a class="buttonLink" href='https://ko-fi.com/Lyrgard' target="_blank">Buy me a coffee</a>
+                        <a class="buttonLink" href='https://ko-fi.com/Lyrgard' target="_blank" rel="noreferrer">Buy me a coffee</a>
                     </div>
                     <div>
-                        <a class="buttonLink" href='https://www.patreon.com/Lyrgard' target="_blank">Become my patron on Patreon</a>
+                        <a class="buttonLink" href='https://www.patreon.com/Lyrgard' target="_blank" rel="noreferrer">Become my patron on Patreon</a>
                     </div>
                     <div>
-                        <a class="buttonLink" data-server="JP" href='https://exviusdb.com/' target="_blank">JP units and items images are a courtesy of EXVIUS DB</a>
+                        <a class="buttonLink" data-server="JP" href='https://exviusdb.com/' target="_blank" rel="noreferrer">JP units and items images are a courtesy of EXVIUS DB</a>
                     </div>
                 </div>
             </div>

--- a/static/builderHelp.html
+++ b/static/builderHelp.html
@@ -99,23 +99,24 @@
                         </div>
                         <div id="collapseThree" class="panel-collapse collapse">
                             <div class="panel-body">
-                                <p>CSS stands for Cascading Style Sheet. CSS allows you to specify various style properties for a given HTML element such as colors, backgrounds, fonts etc. <a href="https://www.tutorialrepublic.com/css-tutorial/" target="_blank">Learn more.</a></p>
+                                <p>CSS stands for Cascading Style Sheet. CSS allows you to specify various style properties for a given HTML element such as colors, backgrounds, fonts etc. <a href="https://www.tutorialrepublic.com/css-tutorial/" target="_blank" rel="noreferrer">Learn more.</a></p>
                             </div>
                         </div>
                     </div>
                 </div>
                 <div class="footerButtons">
                     <div>
-                        <a class="buttonLink" href="https://www.reddit.com/message/compose/?to=lyrgard" target="_blank">Send me a message on reddit</a><a class="buttonLink" href="https://discord.gg/rgXnjhP" target="_blank">chat on FFBE Equip discord server</a>
+                        <a class="buttonLink" href="https://www.reddit.com/message/compose/?to=lyrgard" target="_blank" rel="noreferrer">Send me a message on reddit</a>
+                        <a class="buttonLink" href="https://discord.gg/rgXnjhP" target="_blank" rel="noreferrer">chat on FFBE Equip discord server</a>
                     </div>
                     <div>
-                        <a class="buttonLink" href='https://ko-fi.com/Lyrgard' target="_blank">Donate</a>
+                        <a class="buttonLink" href='https://ko-fi.com/Lyrgard' target="_blank" rel="noreferrer">Buy me a coffee</a>
                     </div>
                     <div>
-                        <a class="buttonLink" href='https://www.patreon.com/Lyrgard' target="_blank">Become a Patron</a>
+                        <a class="buttonLink" href='https://www.patreon.com/Lyrgard' target="_blank" rel="noreferrer">Become my patron on Patreon</a>
                     </div>
                     <div>
-                        <a class="buttonLink" data-server="JP" href='https://exviusdb.com/' target="_blank">JP units and items images are a courtesy of EXVIUS DB</a>
+                        <a class="buttonLink" data-server="JP" href='https://exviusdb.com/' target="_blank" rel="noreferrer">JP units and items images are a courtesy of EXVIUS DB</a>
                     </div>
                 </div>
             </div>

--- a/static/common.js
+++ b/static/common.js
@@ -417,7 +417,7 @@ var toUrl = function(name) {
 
 var toLink = function(text, link = text) {
     if (server == "GL") {
-        return '<span>' + text + '</span><a href="' + toUrl(link) + '" target="_blank" onclick="event.stopPropagation();"><span class="glyphicon glyphicon-new-window wikiLink"></span></a>';
+        return '<span>' + text + '</span><a href="' + toUrl(link) + '" target="_blank" rel="noreferrer" onclick="event.stopPropagation();"><span class="glyphicon glyphicon-new-window wikiLink"></span></a>';
     } else {
         return "<span>" + text + "</span>";
     }
@@ -509,8 +509,8 @@ function addImageChoiceTo(target, name, value, type="checkbox",imagePrefix = "")
 function loadInventory() {
     $.get('googleOAuthUrl', function(result) {
         $('<div id="dialog" title="Authentication">' +
-            '<h4>You\'ll be redirected to a google authentication page</h4><h5 class="loginMessageDetail">This site is using <a href="https://en.wikipedia.org/wiki/OAuth" target="_blank">OAuth2 <span class="glyphicon glyphicon-question-sign"/></a> to access the stored inventory data, so it will never know your google login and password.</h5>' +
-            '<h5 class="loginMessageDetail">The data is stored on the secure FFBE Equip <a href="https://developers.google.com/drive/v3/web/appdata" target="_blank">app folder on Google Drive <span class="glyphicon glyphicon-question-sign"/></a>. FFBE Equip can only access this folder, and no personal file.</h5>' +
+            '<h4>You\'ll be redirected to a google authentication page</h4><h5 class="loginMessageDetail">This site is using <a href="https://en.wikipedia.org/wiki/OAuth" target="_blank" rel="noreferrer">OAuth2 <span class="glyphicon glyphicon-question-sign"/></a> to access the stored inventory data, so it will never know your google login and password.</h5>' +
+            '<h5 class="loginMessageDetail">The data is stored on the secure FFBE Equip <a href="https://developers.google.com/drive/v3/web/appdata" target="_blank" rel="noreferrer">app folder on Google Drive <span class="glyphicon glyphicon-question-sign"/></a>. FFBE Equip can only access this folder, and no personal file.</h5>' +
           '</div>' ).dialog({
             modal: true,
             open: function(event, ui) {

--- a/static/contribute.html
+++ b/static/contribute.html
@@ -101,16 +101,17 @@
                 </div>
                 <div class="footerButtons">
                     <div>
-                        <a class="buttonLink" href="https://www.reddit.com/message/compose/?to=lyrgard">Send me a message on reddit</a>
+                        <a class="buttonLink" href="https://www.reddit.com/message/compose/?to=lyrgard" target="_blank" rel="noreferrer">Send me a message on reddit</a>
+                        <a class="buttonLink" href="https://discord.gg/rgXnjhP" target="_blank" rel="noreferrer">chat on FFBE Equip discord server</a>
                     </div>
                     <div>
-                        <a class="buttonLink" href='https://ko-fi.com/Lyrgard' target="_blank">Buy me a coffee</a>
+                        <a class="buttonLink" href='https://ko-fi.com/Lyrgard' target="_blank" rel="noreferrer">Buy me a coffee</a>
                     </div>
                     <div>
-                        <a class="buttonLink" href='https://www.patreon.com/Lyrgard' target="_blank">Become my patron on Patreon</a>
+                        <a class="buttonLink" href='https://www.patreon.com/Lyrgard' target="_blank" rel="noreferrer">Become my patron on Patreon</a>
                     </div>
                     <div>
-                        <a class="buttonLink" data-server="JP" href='https://exviusdb.com/' target="_blank">JP units and items images are a courtesy of EXVIUS DB</a>
+                        <a class="buttonLink" data-server="JP" href='https://exviusdb.com/' target="_blank" rel="noreferrer">JP units and items images are a courtesy of EXVIUS DB</a>
                     </div>
                 </div>
             </div>

--- a/static/espers.html
+++ b/static/espers.html
@@ -148,16 +148,17 @@
                 </div>
                 <div class="footerButtons">
                     <div>
-                        <a class="buttonLink" href="https://www.reddit.com/message/compose/?to=lyrgard" target="_blank">Send me a message on reddit</a><a class="buttonLink" href="https://discord.gg/rgXnjhP" target="_blank">chat on FFBE Equip discord server</a>
+                        <a class="buttonLink" href="https://www.reddit.com/message/compose/?to=lyrgard" target="_blank" rel="noreferrer">Send me a message on reddit</a>
+                        <a class="buttonLink" href="https://discord.gg/rgXnjhP" target="_blank" rel="noreferrer">chat on FFBE Equip discord server</a>
                     </div>
                     <div>
-                        <a class="buttonLink" href='https://ko-fi.com/Lyrgard' target="_blank">Buy me a coffee</a>
+                        <a class="buttonLink" href='https://ko-fi.com/Lyrgard' target="_blank" rel="noreferrer">Buy me a coffee</a>
                     </div>
                     <div>
-                        <a class="buttonLink" href='https://www.patreon.com/Lyrgard' target="_blank">Become my patron on Patreon</a>
+                        <a class="buttonLink" href='https://www.patreon.com/Lyrgard' target="_blank" rel="noreferrer">Become my patron on Patreon</a>
                     </div>
                     <div>
-                        <a class="buttonLink" data-server="JP" href='https://exviusdb.com/' target="_blank">JP units and items images are a courtesy of EXVIUS DB</a>
+                        <a class="buttonLink" data-server="JP" href='https://exviusdb.com/' target="_blank" rel="noreferrer">JP units and items images are a courtesy of EXVIUS DB</a>
                     </div>
                 </div>
             </div>

--- a/static/espers.js
+++ b/static/espers.js
@@ -241,12 +241,12 @@ function showNode(node, parentNodeHtml, star) {
         nodeHtml.addClass("killer");
     }
     if (node.esperStatsBonus) {
-        var html = '<span class="iconHolder"><img class="icon" src="/img/items/ability_77.png"></img></span><span class="text">ST Reflection Boost<a href="http://exvius.gamepedia.com/ST_Reflection_Boost" target="_blank"><span class="glyphicon glyphicon-new-window wikiLink"></span></a></span><span class="cost">' + node.cost+ ' SP</span>';
+        var html = '<span class="iconHolder"><img class="icon" src="/img/items/ability_77.png"></img></span><span class="text">ST Reflection Boost<a href="http://exvius.gamepedia.com/ST_Reflection_Boost" target="_blank" rel="noreferrer"><span class="glyphicon glyphicon-new-window wikiLink"></span></a></span><span class="cost">' + node.cost+ ' SP</span>';
         nodeHtml.html(html);
         nodeHtml.addClass("ability");
     }
     if (node.lbPerTurn) {
-        var html = '<span class="iconHolder"><img class="icon" src="/img/items/ability_91.png"></img></span><span class="text">+' + node.lbPerTurn.min + ' LS/turn<a href="http://exvius.gamepedia.com/Auto-Limit" target="_blank"><span class="glyphicon glyphicon-new-window wikiLink"></span></a></span><span class="cost">' + node.cost+ ' SP</span>';
+        var html = '<span class="iconHolder"><img class="icon" src="/img/items/ability_91.png"></img></span><span class="text">+' + node.lbPerTurn.min + ' LS/turn<a href="http://exvius.gamepedia.com/Auto-Limit" target="_blank" rel="noreferrer"><span class="glyphicon glyphicon-new-window wikiLink"></span></a></span><span class="cost">' + node.cost+ ' SP</span>';
         nodeHtml.html(html);
         nodeHtml.addClass("ability");
     }

--- a/static/index.html
+++ b/static/index.html
@@ -243,16 +243,17 @@
                 </div>
                 <div class="footerButtons">
                     <div>
-                        <a class="buttonLink" href="https://www.reddit.com/message/compose/?to=lyrgard" target="_blank">Send me a message on reddit</a><a class="buttonLink" href="https://discord.gg/rgXnjhP" target="_blank">chat on FFBE Equip discord server</a>
+                        <a class="buttonLink" href="https://www.reddit.com/message/compose/?to=lyrgard" target="_blank" rel="noreferrer">Send me a message on reddit</a>
+                        <a class="buttonLink" href="https://discord.gg/rgXnjhP" target="_blank" rel="noreferrer">chat on FFBE Equip discord server</a>
                     </div>
                     <div>
-                        <a class="buttonLink" href='https://ko-fi.com/Lyrgard' target="_blank">Buy me a coffee</a>
+                        <a class="buttonLink" href='https://ko-fi.com/Lyrgard' target="_blank" rel="noreferrer">Buy me a coffee</a>
                     </div>
                     <div>
-                        <a class="buttonLink" href='https://www.patreon.com/Lyrgard' target="_blank">Become my patron on Patreon</a>
+                        <a class="buttonLink" href='https://www.patreon.com/Lyrgard' target="_blank" rel="noreferrer">Become my patron on Patreon</a>
                     </div>
                     <div>
-                        <a class="buttonLink" data-server="JP" href='https://exviusdb.com/' target="_blank">JP units and items images are a courtesy of EXVIUS DB</a>
+                        <a class="buttonLink" data-server="JP" href='https://exviusdb.com/' target="_blank" rel="noreferrer">JP units and items images are a courtesy of EXVIUS DB</a>
                     </div>
                 </div>
             </div>

--- a/static/inventory.html
+++ b/static/inventory.html
@@ -97,16 +97,17 @@
 
                 <div class="footerButtons">
                     <div>
-                        <a class="buttonLink" href="https://www.reddit.com/message/compose/?to=lyrgard" target="_blank">Send me a message on reddit</a><a class="buttonLink" href="https://discord.gg/rgXnjhP" target="_blank">chat on FFBE Equip discord server</a>
+                        <a class="buttonLink" href="https://www.reddit.com/message/compose/?to=lyrgard" target="_blank" rel="noreferrer">Send me a message on reddit</a>
+                        <a class="buttonLink" href="https://discord.gg/rgXnjhP" target="_blank" rel="noreferrer">chat on FFBE Equip discord server</a>
                     </div>
                     <div>
-                        <a class="buttonLink" href='https://ko-fi.com/Lyrgard' target="_blank">Buy me a coffee</a>
+                        <a class="buttonLink" href='https://ko-fi.com/Lyrgard' target="_blank" rel="noreferrer">Buy me a coffee</a>
                     </div>
                     <div>
-                        <a class="buttonLink" href='https://www.patreon.com/Lyrgard' target="_blank">Become my patron on Patreon</a>
+                        <a class="buttonLink" href='https://www.patreon.com/Lyrgard' target="_blank" rel="noreferrer">Become my patron on Patreon</a>
                     </div>
                     <div>
-                        <a class="buttonLink" data-server="JP" href='https://exviusdb.com/' target="_blank">JP units and items images are a courtesy of EXVIUS DB</a>
+                        <a class="buttonLink" data-server="JP" href='https://exviusdb.com/' target="_blank" rel="noreferrer">JP units and items images are a courtesy of EXVIUS DB</a>
                     </div>
                 </div>
             </div>

--- a/static/unitSearch.html
+++ b/static/unitSearch.html
@@ -158,16 +158,17 @@
                 </div>
                 <div class="footerButtons">
                     <div>
-                        <a class="buttonLink" href="https://www.reddit.com/message/compose/?to=lyrgard" target="_blank">Send me a message on reddit</a><a class="buttonLink" href="https://discord.gg/rgXnjhP" target="_blank">chat on FFBE Equip discord server</a>
+                        <a class="buttonLink" href="https://www.reddit.com/message/compose/?to=lyrgard" target="_blank" rel="noreferrer">Send me a message on reddit</a>
+                        <a class="buttonLink" href="https://discord.gg/rgXnjhP" target="_blank" rel="noreferrer">chat on FFBE Equip discord server</a>
                     </div>
                     <div>
-                        <a class="buttonLink" href='https://ko-fi.com/Lyrgard' target="_blank">Buy me a coffee</a>
+                        <a class="buttonLink" href='https://ko-fi.com/Lyrgard' target="_blank" rel="noreferrer">Buy me a coffee</a>
                     </div>
                     <div>
-                        <a class="buttonLink" href='https://www.patreon.com/Lyrgard' target="_blank">Become my patron on Patreon</a>
+                        <a class="buttonLink" href='https://www.patreon.com/Lyrgard' target="_blank" rel="noreferrer">Become my patron on Patreon</a>
                     </div>
                     <div>
-                        <a class="buttonLink" data-server="JP" href='https://exviusdb.com/' target="_blank">JP units and items images are a courtesy of EXVIUS DB</a>
+                        <a class="buttonLink" data-server="JP" href='https://exviusdb.com/' target="_blank" rel="noreferrer">JP units and items images are a courtesy of EXVIUS DB</a>
                     </div>
                 </div>
             </div>

--- a/static/units.html
+++ b/static/units.html
@@ -146,16 +146,17 @@
                 </div>
                 <div class="footerButtons">
                     <div>
-                        <a class="buttonLink" href="https://www.reddit.com/message/compose/?to=lyrgard" target="_blank">Send me a message on reddit</a><a class="buttonLink" href="https://discord.gg/rgXnjhP" target="_blank">chat on FFBE Equip discord server</a>
+                        <a class="buttonLink" href="https://www.reddit.com/message/compose/?to=lyrgard" target="_blank" rel="noreferrer">Send me a message on reddit</a>
+                        <a class="buttonLink" href="https://discord.gg/rgXnjhP" target="_blank" rel="noreferrer">chat on FFBE Equip discord server</a>
                     </div>
                     <div>
-                        <a class="buttonLink" href='https://ko-fi.com/Lyrgard' target="_blank">Buy me a coffee</a>
+                        <a class="buttonLink" href='https://ko-fi.com/Lyrgard' target="_blank" rel="noreferrer">Buy me a coffee</a>
                     </div>
                     <div>
-                        <a class="buttonLink" href='https://www.patreon.com/Lyrgard' target="_blank">Become my patron on Patreon</a>
+                        <a class="buttonLink" href='https://www.patreon.com/Lyrgard' target="_blank" rel="noreferrer">Become my patron on Patreon</a>
                     </div>
                     <div>
-                        <a class="buttonLink" data-server="JP" href='https://exviusdb.com/' target="_blank">JP units and items images are a courtesy of EXVIUS DB</a>
+                        <a class="buttonLink" data-server="JP" href='https://exviusdb.com/' target="_blank" rel="noreferrer">JP units and items images are a courtesy of EXVIUS DB</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION

Security improvement again (#124).

When using `target="_blank"` in link, the parent page (on FFBEequip) could be modified by the target page (ex: wiki gamepedia) by using the `window.opener.location` object.

More information: https://mathiasbynens.github.io/rel-noopener

To avoid this issue, we need to define `rel="noreferrer"` for all external links using blank target.