### PR TITLE
Performance: lazyloading of units/equipments image

### DIFF
--- a/static/common.css
+++ b/static/common.css
@@ -292,6 +292,7 @@ body {
 
 .td.type img.icon {
     width: 64px;
+    height: 64px;
     border-radius: 5px;
 }
 
@@ -668,6 +669,15 @@ nav .dropdown-menu li a {
 .choice .btn {
     padding: 3px 6px;
 }
+
+/* Lazyload workaround for Edge 
+   See https://www.andreaverlicchi.eu/lazyload/#dealing-with-microsoft-edge-problems
+*/
+img[data-src] {
+  display: block;
+  min-height: 1px;
+}
+
 
 @media (max-width: 991px) {
     

--- a/static/common.js
+++ b/static/common.js
@@ -24,6 +24,9 @@ var mustSaveUnits = false;
 var mustSaveInventory = false;
 var mustSaveEspers = false;
 var userSettings;
+var lazyLoader = new LazyLoad({
+    elements_selector: 'img.lazyload'
+});
 
 function getImageHtml(item) {
     var html = '<div class="td type">';

--- a/static/common.js
+++ b/static/common.js
@@ -24,9 +24,9 @@ var mustSaveUnits = false;
 var mustSaveInventory = false;
 var mustSaveEspers = false;
 var userSettings;
-var lazyLoader = new LazyLoad({
+var lazyLoader = (window.LazyLoad) ? new LazyLoad({
     elements_selector: 'img.lazyload'
-});
+}) : null;
 
 function getImageHtml(item) {
     var html = '<div class="td type">';

--- a/static/common.js
+++ b/static/common.js
@@ -37,14 +37,18 @@ function getImageHtml(item) {
     if (item.special && item.special.includes("twoHanded")) {
         html += "<img class='miniIcon left' src='img/twoHanded.png' title='Two-handed'>";
     }
+
+    var src_attr = (lazyLoader !== null) ? 'data-src' : 'src';
+    var class_attr = (lazyLoader !== null) ? 'icon lazyload' : 'icon';
+
     if (item.icon) {
-        html += "<img src='img/items/" + item.icon + "' class='icon'></img>";
+        html += "<img "+src_attr+"='img/items/" + item.icon + "' class='"+class_attr+"'></img>";
     } else if (item.type == "esper") {
-        html += "<img src='img/" + escapeName(item.name) + ".png' class='icon'></img>";
+        html += "<img "+src_attr+"='img/" + escapeName(item.name) + ".png' class='"+class_attr+"'></img>";
     } else if (item.type == "unavailable") {
         // no image
     } else {
-        html += "<img src='img/" + item.type + ".png' class='icon'></img>";
+        html += "<img "+src_attr+"='img/" + item.type + ".png' class='"+class_attr+"'></img>";
     }
     html += "</div>";
     return html;

--- a/static/inventory.html
+++ b/static/inventory.html
@@ -232,6 +232,8 @@
                 integrity="sha384-Dziy8F2VlJQLMShA6FHWNul/veM9bCkRUaLqr199K94ntO5QUrLJBEbYegdSkkqX" crossorigin="anonymous"></script>
         <script src="https://cdn.jsdelivr.net/mark.js/8.9.1/jquery.mark.min.js" 
                 integrity="sha384-xm3smXFeZSfehvsiwVXkVZQU/NWHntXE7a/CYQNE/fnBnZi01iu4DRiv+wObGSwn" crossorigin="anonymous"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/vanilla-lazyload/10.15.0/lazyload.min.js"
+                integrity="sha384-eNkRPZsMXXue2PfnzB86JZZm8l6laWo6c2YuXambKDG9ko5QbTktAKCM7MIhZ7AO" crossorigin="anonymous"></script>
 		<script src="lib/jquery.ba-throttle-debounce.min.js"></script>
         <script src="lib/notify.min.js"></script>
         <script src="lib/FileSaver.min.js"></script>

--- a/static/inventory.js
+++ b/static/inventory.js
@@ -160,8 +160,10 @@ function displayItemsByTypeAsync(items, start, div, id, jumpDiv) {
         // Add the jump and the all items to the DOM
         jumpDiv.append(htmlTypeJump);
         div.append(html);
+        // Update lazyloader only for first and last run
+        if (start === 0 || index >= items.length) lazyLoader.update();
+        // Launch next run of type
         if (index < items.length) {
-            // Launch next run of type
             setTimeout(displayItemsByTypeAsync, 0, items, index, div, id, jumpDiv);
         }
     }
@@ -175,7 +177,11 @@ function displayItemsAsync(items, start, div, id, max = 20) {
     }
 
     if (id == displayId) {
+        // Add items to the DOM
         div.append(html);
+        // Update lazyloader only for first and last run
+        if (start === 0 || index >= items.length) lazyLoader.update();
+        // Launch next run of type
         if (index < items.length) {
             setTimeout(displayItemsAsync, 0, items, index, div, id);
         }    

--- a/static/units.html
+++ b/static/units.html
@@ -172,6 +172,8 @@
                 integrity="sha384-xm3smXFeZSfehvsiwVXkVZQU/NWHntXE7a/CYQNE/fnBnZi01iu4DRiv+wObGSwn" crossorigin="anonymous"></script>
         <script src="https://gitcdn.github.io/bootstrap-toggle/2.2.2/js/bootstrap-toggle.min.js" 
                 integrity="sha384-cd07Jx5KAMCf7qM+DveFKIzHXeCSYUrai+VWCPIXbYL7JraHMFL/IXaCKbLtsxyB" crossorigin="anonymous"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/vanilla-lazyload/10.15.0/lazyload.min.js"
+                integrity="sha384-eNkRPZsMXXue2PfnzB86JZZm8l6laWo6c2YuXambKDG9ko5QbTktAKCM7MIhZ7AO" crossorigin="anonymous"></script>
 		<script src="lib/jquery.ba-throttle-debounce.min.js"></script>
         <script src="lib/notify.min.js"></script>
         <script src="lib/FileSaver.min.js"></script>

--- a/static/units.js
+++ b/static/units.js
@@ -41,6 +41,7 @@ function showAlphabeticalSort() {
             }
         }
     });
+    lazyLoader.update();
 }
 
 function showRaritySort(minRarity = 1) {
@@ -58,6 +59,7 @@ function showRaritySort(minRarity = 1) {
             }
         }
     });
+    lazyLoader.update();
 }
 
 function showTMRAlphabeticalSort() {
@@ -77,6 +79,7 @@ function showTMRAlphabeticalSort() {
             }
         }
     });
+    lazyLoader.update();
 }
 
 function showHistory() {
@@ -107,6 +110,7 @@ function showHistory() {
         }
     }
     $("#results").html(html);
+    lazyLoader.update();
 }
 
 function displayStats() {
@@ -335,7 +339,7 @@ function getUnitDisplay(unit, useTmrName = false) {
         if (formToDisplay == 7 && unit.min_rarity != 7) {
             formToDisplay = 6;
         }
-        html += '<div class="unitImageWrapper"><div><img class="unitImage" src="/img/units/unit_ills_' + unit.id.substr(0, unit.id.length - 1) + formToDisplay + '.png"/></div></div>';
+        html += '<div class="unitImageWrapper"><div><img class="unitImage lazyload" data-src="/img/units/unit_ills_' + unit.id.substr(0, unit.id.length - 1) + formToDisplay + '.png"/></div></div>';
         html +='<div class="unitName"><div>';
         if (useTmrName) {
             html += toLink(tmrNameByUnitId[unit.id]);


### PR DESCRIPTION

When showing the units page:
![image](https://user-images.githubusercontent.com/7137528/43827845-25f2a058-9afb-11e8-9333-a2c33196bda6.png)

When showing the inventory page:
![image](https://user-images.githubusercontent.com/7137528/43827888-4956c272-9afb-11e8-8cdf-b472d8bc60d6.png)

This is a crazy amount of request!

To greatly reduce the number of request made, and to improve performance in browser, this PR implements lazy loading of units and equipments image.

With lazy loading, units page:
![image](https://user-images.githubusercontent.com/7137528/43827981-8c12a0ea-9afb-11e8-806e-138d7f5e7625.png)

With lazy loading, inventory page:
![image](https://user-images.githubusercontent.com/7137528/43828020-a18d7d96-9afb-11e8-8060-ac3f2b3bb3fb.png)

Of course, if the user scroll all the way down, all image will be loaded. But at least the first display will not overload the browser. This is especially true for mobile users.

The great library [lazyload](https://github.com/verlok/lazyload) is used to implement this.