### PR TITLE
QoL - Add back to top button and units sidebar fixed when scrolling

### DIFF
--- a/static/builder.html
+++ b/static/builder.html
@@ -16,6 +16,7 @@
         <title>FFBE Equip - Builder</title>
     </head>
     <body>
+        <a href="#" id="scrollToTopButton" style="display: none;" title="Scroll back to the top"><span></span></a>
         <div class="container-fluid">
             <div class="col-xs-12">
                 <nav class="col-xs-12 navbar navbar-default">

--- a/static/common.css
+++ b/static/common.css
@@ -669,6 +669,35 @@ nav .dropdown-menu li a {
     padding: 3px 6px;
 }
 
+#scrollToTopButton {
+    display: none;
+    position: fixed;
+    right: 10px;
+    bottom: 10px;
+    cursor: pointer;
+    width: 50px;
+    height: 50px;
+    border-radius: 50px;
+    background-color: #052464;
+    opacity: 0.5;
+}
+
+#scrollToTopButton:hover {
+    opacity: 1;
+}
+
+#scrollToTopButton span {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    margin-left: -8px;
+    margin-top: -12px;
+    height: 0;
+    width: 0;
+    border: 8px solid transparent;
+    border-bottom-color: #ffffff;
+}
+
 @media (max-width: 991px) {
     
     #navigationMenu #mobileMenu {

--- a/static/common.css
+++ b/static/common.css
@@ -680,6 +680,7 @@ nav .dropdown-menu li a {
     border-radius: 50px;
     background-color: #052464;
     opacity: 0.5;
+    z-index: 9999;
 }
 
 #scrollToTopButton:hover {

--- a/static/common.js
+++ b/static/common.js
@@ -1430,4 +1430,23 @@ $(function() {
         e.stopPropagation();
         e.preventDefault();
     });
+
+    /* Back to top button feature */
+    var $scroll = $('#scrollToTopButton');
+    if ($scroll) {
+        // Detect when user start to scroll down
+        $(window).scroll($.debounce(100, function(){ 
+            if ($(this).scrollTop() > 100) { 
+                $scroll.fadeIn(200);
+            } else { 
+                $scroll.fadeOut(200);
+            } 
+        }));
+
+        // Back to top when clicking on link
+        $scroll.click(function(){ 
+            $("html, body").animate({ scrollTop: 0 }, 400); 
+            return false; 
+        }); 
+    }
 });

--- a/static/contribute.html
+++ b/static/contribute.html
@@ -12,6 +12,7 @@
         <title>FFBE Equip - Contribution</title>
     </head>
     <body>
+        <a href="#" id="scrollToTopButton" style="display: none;" title="Scroll back to the top"><span></span></a>
         <div class="container-fluid">
             <div class="col-xs-12">
                 <nav class="col-xs-12 navbar navbar-default">

--- a/static/espers.html
+++ b/static/espers.html
@@ -12,6 +12,7 @@
         <title>FFBE Equip : Espers</title>
     </head>
     <body>
+        <a href="#" id="scrollToTopButton" style="display: none;" title="Scroll back to the top"><span></span></a>
         <div id="loaderGlassPanel" class="hidden">
             <div id="loader"></div>
         </div>

--- a/static/inventory.html
+++ b/static/inventory.html
@@ -12,6 +12,7 @@
         <title>FFBE Equip : Inventory</title>
     </head>
     <body>
+        <a href="#" id="scrollToTopButton" style="display: none;" title="Scroll back to the top"><span></span></a>
         <div class="container-fluid">
             <div class="col-xs-12">
                 <nav class="col-xs-12 navbar navbar-default">

--- a/static/unitSearch.html
+++ b/static/unitSearch.html
@@ -14,6 +14,7 @@
         <title>FFBE Equip - Unit Search</title>
     </head>
     <body>
+        <a href="#" id="scrollToTopButton" style="display: none;" title="Scroll back to the top"><span></span></a>
         <div class="container-fluid">
             <div class="col-xs-12">
                 <nav class="col-xs-12 navbar navbar-default">

--- a/static/units.css
+++ b/static/units.css
@@ -333,3 +333,11 @@
     text-align: center;
     font-weight: bold;
 }
+
+.unitsSidebar.fixed {
+    position: fixed;
+    width: 16.66666667%;
+    top: 10px;
+    left: 15px;
+    padding: 0 15px;
+}

--- a/static/units.css
+++ b/static/units.css
@@ -340,4 +340,5 @@
     top: 10px;
     left: 15px;
     padding: 0 15px;
+    z-index: 9999;
 }

--- a/static/units.html
+++ b/static/units.html
@@ -13,6 +13,7 @@
         <title>FFBE Equip : Units</title>
     </head>
     <body>
+        <a href="#" id="scrollToTopButton" style="display: none;" title="Scroll back to the top"><span></span></a>
         <div id="loaderGlassPanel" class="hidden">
             <div id="loader"></div>
         </div>

--- a/static/units.html
+++ b/static/units.html
@@ -76,33 +76,35 @@
                 </nav>
             </div>
 
-            <div class="col-xs-2 ">
-                <div class="stats hidden">
-                    <h4>All units</h4>
-                    <div class="all">
-                        <div class="star7"><img class="crystal" src="img/sevenStarCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
-                        <div class="star5"><img class="crystal" src="img/rainbowCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
-                        <div class="star4"><img class="crystal" src="img/goldCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
-                        <div class="star3"><img class="crystal" src="img/blueCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
+            <div class="col-xs-2">
+                <div class="unitsSidebar">
+                    <div class="stats hidden">
+                        <h4>All units</h4>
+                        <div class="all">
+                            <div class="star7"><img class="crystal" src="img/sevenStarCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
+                            <div class="star5"><img class="crystal" src="img/rainbowCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
+                            <div class="star4"><img class="crystal" src="img/goldCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
+                            <div class="star3"><img class="crystal" src="img/blueCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
+                        </div>
+                        <h4>Not-limited units</h4>
+                        <div class="withoutTimeLimited">
+                            <div class="star7"><img class="crystal" src="img/sevenStarCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
+                            <div class="star5"><img class="crystal" src="img/rainbowCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
+                            <div class="star4"><img class="crystal" src="img/goldCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
+                            <div class="star3"><img class="crystal" src="img/blueCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
+                        </div>
+                        <h4>Time-limited units</h4>
+                        <div class="timeLimited">
+                            <div class="star7"><img class="crystal" src="img/sevenStarCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
+                            <div class="star5"><img class="crystal" src="img/rainbowCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
+                            <div class="star4"><img class="crystal" src="img/goldCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
+                            <div class="star3"><img class="crystal" src="img/blueCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
+                        </div>
                     </div>
-                    <h4>Not-limited units</h4>
-                    <div class="withoutTimeLimited">
-                        <div class="star7"><img class="crystal" src="img/sevenStarCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
-                        <div class="star5"><img class="crystal" src="img/rainbowCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
-                        <div class="star4"><img class="crystal" src="img/goldCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
-                        <div class="star3"><img class="crystal" src="img/blueCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
+                    <div id="mode">
+                        <input id="modeToggle" type="checkbox">
+                        <span class="info">(Switch to Edit mode to have full control on each unit numbers)</span>
                     </div>
-                    <h4>Time-limited units</h4>
-                    <div class="timeLimited">
-                        <div class="star7"><img class="crystal" src="img/sevenStarCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
-                        <div class="star5"><img class="crystal" src="img/rainbowCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
-                        <div class="star4"><img class="crystal" src="img/goldCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
-                        <div class="star3"><img class="crystal" src="img/blueCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
-                    </div>
-                </div>
-                <div id="mode">
-                    <input id="modeToggle" type="checkbox">
-                    <span class="info">(Switch to Edit mode to have full control on each unit numbers)</span>
                 </div>
             </div>
             <div  class="col-xs-10 col-lg-8">

--- a/static/units.js
+++ b/static/units.js
@@ -903,6 +903,8 @@ function startPage() {
 
     $("#results").addClass(server);
 
+    var $unitsSidebar = $('.unitsSidebar');
+    var unitsSidebarTopPos = $unitsSidebar.offset().top;
 
     $(window).on("beforeunload", function () {
         if  (saveNeeded) {
@@ -916,7 +918,14 @@ function startPage() {
         if (e.keyCode === 27) {
             $("#searchBox").val('').trigger('input').focus();
         }
-    });;
+    }).on('scroll', $.debounce(50, function(){
+        // Detect when user scroll, and fix the sidebar to be always accessible
+        if ($(this).scrollTop() > unitsSidebarTopPos) { 
+            $unitsSidebar.addClass('fixed');
+        } else { 
+            $unitsSidebar.removeClass('fixed');
+        } 
+    }));;
 
     $("#searchBox").on("input", $.debounce(300,updateResults));
     


### PR DESCRIPTION

As requested on Discord: a back to top floating button, visible on the bottom right corner when scrolling.

Also added a nice QoL: when scrolling in the unit page, the left sidebar will stay fixed so the stats & edit button will always stay visible.

Here how it looks:
![image](https://user-images.githubusercontent.com/7137528/43835820-90e70f30-9b13-11e8-989e-5dba8ba35a49.png)
