### PR TITLE
Rework Units page for small screen

### DIFF
--- a/static/units.css
+++ b/static/units.css
@@ -330,8 +330,7 @@
     color: #999;
 }
 
-.farmable:hover .farmedButton {
-    display: block;
+.farmable .farmedButton {
     position: absolute;
     top: -5px;
     right: -6px;
@@ -346,7 +345,8 @@
     display: none;
 }
 
-.awakenable:hover .awakenButton {
+.awakenable:hover .awakenButton,
+.farmable:hover .farmedButton {
     display: block;
 }
 
@@ -511,6 +511,11 @@
     
     .unit.sevenStars:hover .numberDiv .glyphicon {
         color: #F9D2DA;
+    }
+    
+    .farmable .farmedButton,
+    .awakenable .awakenButton {
+        display: block;
     }
 }
 

--- a/static/units.css
+++ b/static/units.css
@@ -1,3 +1,67 @@
+
+.unitsWrapper {
+    clear: both; /* needed because of floating header above */
+    display: flex;
+    align-items: stretch;
+}
+
+.unitsSidebar .unitsSidebarButton {
+    display: block;
+    border: 1px solid #c8c8c8;
+    background: #f7f7f7;
+    border-radius: 4px;
+    padding: 6px;
+    margin: 20px auto 0 auto;
+    color: #747474;
+    opacity: 0.5;
+}
+
+.unitsSidebar .unitsSidebarButton:hover {
+    border: 1px solid #808080;
+    background: #f0f0f0;
+    opacity: 1;
+}
+
+.unitsContent {
+    position: relative;
+}
+
+.unitsSidebar {
+    padding: 0 10px;
+    overflow: hidden;
+    flex-grow: 0;
+    flex-shrink: 0;
+    width: 250px;
+}
+
+.unitsSidebar .unitsSidebarButton .glyphicon {
+    transition: transform .3s;
+}
+
+.unitsSidebar.collapsed {
+    width: 100px;
+}
+
+.unitsSidebar.collapsed .unitsSidebarButton {
+    opacity: 0.85;
+}
+
+.unitsSidebar.collapsed .unitsSidebarButton .glyphicon {
+    transform: rotate(180deg);
+}
+
+.unitsSidebar.collapsed .collapsedHidden {
+    display: none;
+}
+
+.unitsSidebar .unitsSidebarInternal.fixed {
+    position: fixed;
+    top: 5px;
+    left: 15px;
+    z-index: 9999;
+    padding: 0 10px;
+}
+
 .unitList {
     display: flex;
     flex-wrap: wrap;
@@ -211,18 +275,34 @@
     padding-left: 15px;
 }
 
-.explanation {
-    position: absolute;
-    top: 15px;
-    right: 25px;
-}
-
 #exportLinks {
     position: absolute;
     top: 20px;
     left: 320px;
+    z-index: 1;
 }
 
+#exportLinks a.dropdown-toggle {
+    margin-left: 10px;
+    padding: 4px 6px;
+    border: 1px solid #c8c8c8;
+    background: #f7f7f7;
+    border-radius: 4px;
+    white-space: nowrap;
+}
+
+#exportLinks a.dropdown-toggle:hover {
+    border: 1px solid #808080;
+    background: #f0f0f0;
+    text-decoration: none;
+}
+
+.explanation {
+    position: absolute;
+    top: 15px;
+    right: 25px;
+    font-size: 0.9em;
+}
 
 .readOnly .explanation.readOnly {
     display: block;
@@ -277,8 +357,19 @@
     align-items: center;
 }
 
+.stats .statsGroup {
+    flex-grow: 1;
+    text-align: center;
+}
+
+.stats .statsGroup > div {
+    display: inline-block;
+}
+
+
 .stats h4 {
-    margin-top: 20px;
+    font-size: 1.2em;
+    margin-top: 15px;
 }
 
 .stats .crystal {
@@ -334,11 +425,135 @@
     font-weight: bold;
 }
 
-.unitsSidebar.fixed {
-    position: fixed;
-    width: 16.66666667%;
-    top: 10px;
-    left: 15px;
-    padding: 0 15px;
-    z-index: 9999;
+/* For small screen, show stats in line and mode fixed lower right */
+@media (max-width: 768px) {
+    
+    .unitsWrapper {
+        display: block;
+    }
+
+    .unitsSidebar {
+        width: auto;
+    }
+
+    .unitsSidebar .unitsSidebarButton {
+        margin: 5px 0 15px 0;
+    }
+    
+    .unitsSidebar .unitsSidebarButton .glyphicon {
+        transform: rotate(-90deg);
+    }
+
+    .unitsSidebar.collapsed {
+        width: auto;
+    }
+
+    .unitsSidebar.collapsed .toggle.btn .collapsedHidden,
+    .unitsSidebar.collapsed .unitsSidebarButton .collapsedHidden {
+        display: inline;
+    }
+
+    .unitsSidebar.collapsed .unitsSidebarButton .glyphicon {
+        transform: rotate(90deg);
+    }
+
+    .stats {
+        margin-top: 0;
+        margin-bottom: 20px;
+        flex-direction: row;
+    }
+
+    .stats h4 {
+        margin-top: 0;
+    }
+
+    #mode {
+        position: fixed;
+        z-index: 9999;
+        right: 10px;
+        bottom: 20px;
+        box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
+        border-radius: 10px;
+        border: none;
+        background: none;
+        opacity: 0.75;
+    }
+
+    #mode:hover {
+        opacity: 1;
+    }
+
+    #mode .info {
+        display: none;
+    }
+    
+    #exportLinks a.dropdown-toggle {
+        padding: 6px 8px;
+    }
+    
+    /* Adapt scroll button with mode toggle selector */
+    #scrollToTopButton.withToggleSelector {
+        bottom: 67px; /* 20px margin + 37px height + 10px */
+        right: 15px; 
+    }
+
+    .unit .modifyCounterButton {
+        color: #337ab7;
+    }
+
+    .unit:hover .modifyCounterButton {
+        color: #d2edf9;
+    }
+}
+
+@media (min-width: 768px) {
+    .unitsSidebar.collapsed #mode .toggle.btn {
+        width: 100% !important;
+    }
+}
+
+@media (min-width: 1200px) {
+    .unitsContent {
+        max-width: 85%;
+    }
+}
+
+@media (max-width: 1200px) {
+    .unitsSidebar .unitsSidebarInternal.fixed {
+        left: 0px;
+    }
+}
+
+@media (max-width: 550px) {
+    .stats {
+        font-size: 0.75em;
+    }
+    
+    #exportLinks {
+        display: none;
+    }
+
+    .explanation {
+        display: none;
+    }
+
+    .stats .star7,
+    .stats .star5,
+    .stats .star4,
+    .stats .star3 {
+        white-space: nowrap;
+    }
+
+    .stats .value {
+        width: 10px;
+        margin-right: 2px;
+    }
+    
+    .stats .total {
+        width: 15px;
+    }
+    
+    .stats .number {
+        width: 30px;
+    }
 }

--- a/static/units.css
+++ b/static/units.css
@@ -441,7 +441,7 @@
     }
     
     .unitsSidebar .unitsSidebarButton .glyphicon {
-        transform: rotate(-90deg);
+        transform: rotate(90deg);
     }
 
     .unitsSidebar.collapsed {
@@ -454,7 +454,7 @@
     }
 
     .unitsSidebar.collapsed .unitsSidebarButton .glyphicon {
-        transform: rotate(90deg);
+        transform: rotate(-90deg);
     }
 
     .stats {

--- a/static/units.css
+++ b/static/units.css
@@ -497,12 +497,20 @@
         right: 15px; 
     }
 
-    .unit .modifyCounterButton {
+    .unit .numberDiv .glyphicon {
         color: #337ab7;
     }
 
-    .unit:hover .modifyCounterButton {
+    .unit:hover .numberDiv .glyphicon {
         color: #d2edf9;
+    }
+    
+    .unit.sevenStars .numberDiv .glyphicon {
+        color: #A67D85;
+    }
+    
+    .unit.sevenStars:hover .numberDiv .glyphicon {
+        color: #F9D2DA;
     }
 }
 

--- a/static/units.html
+++ b/static/units.html
@@ -1,6 +1,11 @@
 <html lang="en">
     <head>
-		<meta charset="UTF-8">
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        
+        <title>FFBE Equip : Units</title>
+        <link rel="icon" type="image/png" href="/img/heavyArmor.png">
+        
         <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" 
               integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
 		<link rel="stylesheet" type="text/css" href="common.css?version=3">
@@ -9,11 +14,9 @@
         <link rel="stylesheet" type="text/css" href="https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css"
               integrity="sha384-xewr6kSkq3dBbEtB6Z/3oFZmknWn7nHqhLVLrYgzEFRbU/DHSxW7K3B44yWUN60D" crossorigin="anonymous">
         <link href="https://gitcdn.github.io/bootstrap-toggle/2.2.2/css/bootstrap-toggle.min.css" rel="stylesheet">
-        <link rel="icon" type="image/png" href="/img/heavyArmor.png">
-        <title>FFBE Equip : Units</title>
     </head>
     <body>
-        <a href="#" id="scrollToTopButton" style="display: none;" title="Scroll back to the top"><span></span></a>
+        <a href="#" id="scrollToTopButton" class="withToggleSelector" style="display: none;" title="Scroll back to the top"><span></span></a>
         <div id="loaderGlassPanel" class="hidden">
             <div id="loader"></div>
         </div>
@@ -63,7 +66,7 @@
                         <div class="buttonDiv">
                             <button class="hidden btn btn-default loadInventory" onclick="loadInventory()">Log in</button>
                             <a href="/googleOAuthLogout">
-                              <span class="hidden glyphicon glyphicon-off logOut" title="logout"></span>
+                            <span class="hidden glyphicon glyphicon-off logOut" title="logout"></span>
                             </a>
                         </div>
                         <div id="inventoryStatus">
@@ -72,96 +75,119 @@
                             <div class="loader"></div>
                         </div>
                     </div>
-                    
                 </nav>
             </div>
-
-            <div class="col-xs-2">
+            <div class="unitsWrapper">
                 <div class="unitsSidebar">
-                    <div class="stats hidden">
-                        <h4>All units</h4>
-                        <div class="all">
-                            <div class="star7"><img class="crystal" src="img/sevenStarCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
-                            <div class="star5"><img class="crystal" src="img/rainbowCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
-                            <div class="star4"><img class="crystal" src="img/goldCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
-                            <div class="star3"><img class="crystal" src="img/blueCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
+                    <div class="unitsSidebarInternal">
+                        <button class="unitsSidebarButton hidden" title="Toggle sidebar">
+                            <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
+                            <span class="collapsedHidden">Toggle stats</span>
+                        </button>
+                        <div class="stats hidden collapsedHidden">
+                            <div class="statsGroup">
+                                <h4>All units</h4>
+                                <div class="all">
+                                    <div class="star7"><img class="crystal" src="img/sevenStarCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
+                                    <div class="star5"><img class="crystal" src="img/rainbowCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
+                                    <div class="star4"><img class="crystal" src="img/goldCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
+                                    <div class="star3"><img class="crystal" src="img/blueCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
+                                </div>
+                            </div>
+                            <div class="statsGroup">
+                                <h4>Not-limited units</h4>
+                                <div class="withoutTimeLimited">
+                                    <div class="star7"><img class="crystal" src="img/sevenStarCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
+                                    <div class="star5"><img class="crystal" src="img/rainbowCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
+                                    <div class="star4"><img class="crystal" src="img/goldCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
+                                    <div class="star3"><img class="crystal" src="img/blueCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
+                                </div>
+                            </div>
+                            <div class="statsGroup">
+                                <h4>Time-limited units</h4>
+                                <div class="timeLimited">
+                                    <div class="star7"><img class="crystal" src="img/sevenStarCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
+                                    <div class="star5"><img class="crystal" src="img/rainbowCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
+                                    <div class="star4"><img class="crystal" src="img/goldCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
+                                    <div class="star3"><img class="crystal" src="img/blueCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
+                                </div>
+                            </div>
                         </div>
-                        <h4>Not-limited units</h4>
-                        <div class="withoutTimeLimited">
-                            <div class="star7"><img class="crystal" src="img/sevenStarCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
-                            <div class="star5"><img class="crystal" src="img/rainbowCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
-                            <div class="star4"><img class="crystal" src="img/goldCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
-                            <div class="star3"><img class="crystal" src="img/blueCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
+                        <div id="mode">
+                            <input id="modeToggle" type="checkbox">
+                            <span class="info collapsedHidden">(Switch to Edit mode to have full control on each unit numbers)</span>
                         </div>
-                        <h4>Time-limited units</h4>
-                        <div class="timeLimited">
-                            <div class="star7"><img class="crystal" src="img/sevenStarCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
-                            <div class="star5"><img class="crystal" src="img/rainbowCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
-                            <div class="star4"><img class="crystal" src="img/goldCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
-                            <div class="star3"><img class="crystal" src="img/blueCrystal.png"/><span class="value"></span>/<span class="total"></span><span class="number"></span></div>
-                        </div>
-                    </div>
-                    <div id="mode">
-                        <input id="modeToggle" type="checkbox">
-                        <span class="info">(Switch to Edit mode to have full control on each unit numbers)</span>
                     </div>
                 </div>
-            </div>
-            <div  class="col-xs-10 col-lg-8">
+                <div class="unitsContent">
 
-                <span id="pleaseWaitMessage" class="h4">Please wait for your units to be loaded</span>
-                <span id="loginMessage" class="h4 hidden">Log-in to display your units</span>
-                <div id="units" class="hidden">
-                    <ul id="tabs" class="nav nav-tabs">
-                        <li class="raritySort" onclick="showRaritySort()"><a><img src="img/star_icon.png"/></a></li>
-                        <li class="alphabeticalSort" onclick="showAlphabeticalSort()"><a><img src="img/sort-a-z.png"/></a></li>
-                        <li class="tmrAlphabeticalSort" onclick="showTMRAlphabeticalSort()"><a><img src="img/sort-tmr.png"/></a></li>
-                        <li class="history" onclick="showHistory()"><a><img src="img/history.png"/></a></li>
-                    </ul>
-                    <div id="exportLinks" class="dropdown">
-                        <a class=" dropdown-toggle link" type="button" data-toggle="dropdown"><span class="glyphicon glyphicon-share-alt"></span> Share unit collection<span class="caret"></span></a>
-                        <ul class="dropdown-menu">
-                            <li><a class="link" onclick="exportAsImage();"><span class="glyphicon glyphicon-camera"></span> Export as image</a></li>
-                            <li><a class="link" onclick="exportAsImage(5);"><span class="glyphicon glyphicon-camera"></span> Export only 5*+ as image</a></li>
-                            <li><a class="link" onclick="exportAsImage(7);"><span class="glyphicon glyphicon-camera"></span> Export only 7* as image</a></li>
-                            <li><a class="link" onclick="exportAsCsv()"><span class="glyphicon glyphicon-list"></span> Export as CSV</a></li>
-                            <li><a class="link" onclick="exportAsText()"><span class="glyphicon glyphicon-list"></span> Export as simple text</a></li>
-                            <li><a class="link" onclick="showPublicUnitCollectionLink()"><span class="glyphicon glyphicon-link"></span> Get public unit collection link</a></li>
+                    <span id="pleaseWaitMessage" class="h4">Please wait for your units to be loaded</span>
+                    <span id="loginMessage" class="h4 hidden">Log-in to display your units</span>
+                    <div id="units" class="hidden">
+                        <ul id="tabs" class="nav nav-tabs">
+                            <li class="raritySort" onclick="showRaritySort()"><a><img src="img/star_icon.png"/></a></li>
+                            <li class="alphabeticalSort" onclick="showAlphabeticalSort()"><a><img src="img/sort-a-z.png"/></a></li>
+                            <li class="tmrAlphabeticalSort" onclick="showTMRAlphabeticalSort()"><a><img src="img/sort-tmr.png"/></a></li>
+                            <li class="history" onclick="showHistory()"><a><img src="img/history.png"/></a></li>
                         </ul>
-                    </div>
-                    <div class="explanation ">
-                        <div>Left number: how many time you own this unit</div>
-                        <div>Right number: how many time you can still farm the TMR</div>
-                    </div>
-                    <div class="explanation readOnly">
-                        <div>Left number: how many time the unit is owned</div>
-                        <div>Right number: how many time the TMR is owned</div>
-                    </div>
+                        <div id="exportLinks" class="dropdown">
+                            <a class="dropdown-toggle link" type="button" data-toggle="dropdown">
+                                <span class="glyphicon glyphicon-share-alt"></span> 
+                                <span class="hidden-xs hidden-sm">
+                                    Share unit collection<span class="caret"></span>
+                            </span>
+                            </a>
+                            <ul class="dropdown-menu">
+                                <li><a class="link" onclick="exportAsImage();"><span class="glyphicon glyphicon-camera"></span> Export as image</a></li>
+                                <li><a class="link" onclick="exportAsImage(5);"><span class="glyphicon glyphicon-camera"></span> Export only 5*+ as image</a></li>
+                                <li><a class="link" onclick="exportAsImage(7);"><span class="glyphicon glyphicon-camera"></span> Export only 7* as image</a></li>
+                                <li><a class="link" onclick="exportAsCsv()"><span class="glyphicon glyphicon-list"></span> Export as CSV</a></li>
+                                <li><a class="link" onclick="exportAsText()"><span class="glyphicon glyphicon-list"></span> Export as simple text</a></li>
+                                <li><a class="link" onclick="showPublicUnitCollectionLink()"><span class="glyphicon glyphicon-link"></span> Get public unit collection link</a></li>
+                            </ul>
+                        </div>
+                        <div class="explanation hidden-xs hidden-sm hidden-md">
+                            <div>Left number: how many time you own this unit</div>
+                            <div>Right number: how many time you can still farm the TMR</div>
+                        </div>
+                        <div class="explanation hidden-lg">
+                            <div>Left: nb of unit owned</div>
+                            <div>Right: nb of TMR left</div>
+                        </div>
+                        <div class="explanation readOnly hidden-xs hidden-sm hidden-md">
+                            <div>Left number: how many time the unit is owned</div>
+                            <div>Right number: how many time the TMR is owned</div>
+                        </div>
+                        <div class="explanation readOnly hidden-lg">
+                            <div>Left: nb of unit owned</div>
+                            <div>Right: nb of TMR owned</div>
+                        </div>
 
-                    <div class="result-tab-pane">
-                        <div class="panel-body" style="padding:0;">
-                            <div class="col-xs-12">
-                                <input id="searchBox" type="text" class="form-control" placeholder="Enter unit name"/>
-                            </div>
-                            <div id="results" class="col-xs-12 simpleMode">
+                        <div class="result-tab-pane">
+                            <div class="panel-body" style="padding:0;">
+                                <div class="col-xs-12">
+                                    <input id="searchBox" type="text" class="form-control" placeholder="Enter unit name"/>
+                                </div>
+                                <div id="results" class="col-xs-12 simpleMode">
 
+                                </div>
                             </div>
                         </div>
                     </div>
-                </div>
-                <div class="footerButtons">
-                    <div>
-                        <a class="buttonLink" href="https://www.reddit.com/message/compose/?to=lyrgard" target="_blank" rel="noreferrer">Send me a message on reddit</a>
-                        <a class="buttonLink" href="https://discord.gg/rgXnjhP" target="_blank" rel="noreferrer">chat on FFBE Equip discord server</a>
-                    </div>
-                    <div>
-                        <a class="buttonLink" href='https://ko-fi.com/Lyrgard' target="_blank" rel="noreferrer">Buy me a coffee</a>
-                    </div>
-                    <div>
-                        <a class="buttonLink" href='https://www.patreon.com/Lyrgard' target="_blank" rel="noreferrer">Become my patron on Patreon</a>
-                    </div>
-                    <div>
-                        <a class="buttonLink" data-server="JP" href='https://exviusdb.com/' target="_blank" rel="noreferrer">JP units and items images are a courtesy of EXVIUS DB</a>
+                    <div class="footerButtons">
+                        <div>
+                            <a class="buttonLink" href="https://www.reddit.com/message/compose/?to=lyrgard" target="_blank" rel="noreferrer">Send me a message on reddit</a>
+                            <a class="buttonLink" href="https://discord.gg/rgXnjhP" target="_blank" rel="noreferrer">chat on FFBE Equip discord server</a>
+                        </div>
+                        <div>
+                            <a class="buttonLink" href='https://ko-fi.com/Lyrgard' target="_blank" rel="noreferrer">Buy me a coffee</a>
+                        </div>
+                        <div>
+                            <a class="buttonLink" href='https://www.patreon.com/Lyrgard' target="_blank" rel="noreferrer">Become my patron on Patreon</a>
+                        </div>
+                        <div>
+                            <a class="buttonLink" data-server="JP" href='https://exviusdb.com/' target="_blank" rel="noreferrer">JP units and items images are a courtesy of EXVIUS DB</a>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/static/units.js
+++ b/static/units.js
@@ -208,7 +208,7 @@ function displayStats() {
     $(".stats .timeLimited .star3 .total").text(stats.timeLimited["3"].total);
     $(".stats .timeLimited .star3 .number").text("(" + stats.timeLimited["3"].number + ")");
     
-    $(".stats").removeClass("hidden");
+    $(".unitsSidebar .hidden").removeClass("hidden");
 }
 
 // Construct HTML of the results. String concatenation was chosen for rendering speed.
@@ -913,35 +913,61 @@ function startPage() {
 
     $("#results").addClass(server);
 
-    var $unitsSidebar = $('.unitsSidebar');
-    var unitsSidebarTopPos = $unitsSidebar.offset().top;
+    var $window = $(window);
 
-    $(window).on("beforeunload", function () {
+    $window.on("beforeunload", function () {
         if  (saveNeeded) {
             return "Unsaved change exists !";
         }
         if (savePublicLinkNeeded) {
             savePublicLink();
         }
-    }).on('keyup', function (e) {
+    });
+    
+    $window.on('keyup', function (e) {
         // Reset search if escape is used
         if (e.keyCode === 27) {
             $("#searchBox").val('').trigger('input').focus();
         }
-    }).on('scroll', $.debounce(50, function(){
+    });
+    
+    var $unitsSidebar = $('.unitsSidebar');
+    var $unitsSidebarInternal = $unitsSidebar.find('.unitsSidebarInternal');
+    var unitsSidebarTopPos = $unitsSidebar.offset().top;
+    var sidebarFixedWidthLimit = 768;
+
+    $window.on('scroll', $.debounce(50, function(){
         // Detect when user scroll, and fix the sidebar to be always accessible
-        if ($(this).scrollTop() > unitsSidebarTopPos) { 
-            $unitsSidebar.addClass('fixed');
+        if ($(this).scrollTop() > unitsSidebarTopPos && $window.outerWidth() > sidebarFixedWidthLimit) {
+            if (!$unitsSidebarInternal.hasClass('fixed')) {
+                $unitsSidebarInternal.css('width', $unitsSidebar.outerWidth() + 'px');
+                $unitsSidebarInternal.addClass('fixed');
+            }
         } else { 
-            $unitsSidebar.removeClass('fixed');
+            if ($unitsSidebarInternal.hasClass('fixed')) {
+                $unitsSidebarInternal.css('width', '');
+                $unitsSidebarInternal.removeClass('fixed');
+            }
         } 
-    }));;
+    }));
+    $window.on('resize', $.debounce(150, function(){
+        if ($unitsSidebarInternal.hasClass('fixed') && $window.outerWidth() <= sidebarFixedWidthLimit) {
+            $unitsSidebarInternal.css('width', '');
+            $unitsSidebarInternal.removeClass('fixed');
+        }
+    }));
+    $('.unitsSidebarButton').click(function() {
+        $unitsSidebar.toggleClass('collapsed');
+        if ($unitsSidebarInternal.hasClass('fixed')) {
+            $unitsSidebarInternal.css('width', $unitsSidebar.outerWidth() + 'px');
+        }
+    });
 
     $("#searchBox").on("input", $.debounce(300,updateResults));
     
     $('#modeToggle').bootstrapToggle({
-        on: 'Simple Mode',
-        off: 'Edit Mode',
+        on: 'Simple <span class="collapsedHidden">Mode</span>',
+        off: 'Edit <span class="collapsedHidden">Mode</span>',
         onstyle: "default",
         offstyle: "default"
     });


### PR DESCRIPTION

Indigo here again with a nice PR to improve the Units page for small screen!

Here how the **actual** page looks on various screen size:

![image](https://user-images.githubusercontent.com/7137528/43911696-6a47c23c-9c00-11e8-8ffe-7a9be57eff6c.png)

---

Here how the **new** page looks on various screen size:

![image](https://user-images.githubusercontent.com/7137528/43911707-706ef95a-9c00-11e8-98d3-571c5287764d.png)

---

Modified: 
- The left sidebar (with stats and simple/edit mode toggle) can be collapsed to gain space
- The sidebar is no longer visible on tablet and mobile. The stats are moved at the top (collapsable) and the simple/edit mode toggle is fixed on the bottom right corner.
- The "share unit collection" looks more like a button, has its text removed on tablet and is not visible on mobile