### PR TITLE
Rework inventory for small screen

### DIFF
--- a/static/inventory.css
+++ b/static/inventory.css
@@ -1,3 +1,68 @@
+
+.itemsWrapper {
+    clear: both; /* needed because of floating header above */
+    display: flex;
+    align-items: stretch;
+}
+
+.itemsSidebar .itemsSidebarButton {
+    display: block;
+    border: 1px solid #c8c8c8;
+    background: #f7f7f7;
+    border-radius: 4px;
+    padding: 6px;
+    margin: 20px auto 0 auto;
+    color: #747474;
+    opacity: 0.5;
+}
+
+.itemsSidebar .itemsSidebarButton:hover {
+    border: 1px solid #808080;
+    background: #f0f0f0;
+    opacity: 1;
+}
+
+.itemsContent {
+    position: relative;
+    flex-grow: 1;
+}
+
+.itemsSidebar {
+    padding: 0 10px;
+    overflow: hidden;
+    flex-grow: 0;
+    flex-shrink: 0;
+    width: 250px;
+}
+
+.itemsSidebar .itemsSidebarButton .glyphicon {
+    transition: transform .3s;
+}
+
+.itemsSidebar.collapsed {
+    width: 100px;
+}
+
+.itemsSidebar.collapsed .itemsSidebarButton {
+    opacity: 0.85;
+}
+
+.itemsSidebar.collapsed .itemsSidebarButton .glyphicon {
+    transform: rotate(180deg);
+}
+
+.itemsSidebar.collapsed .collapsedHidden {
+    display: none;
+}
+
+.unitList {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+
+
 .item {
     display: flex;
     flex-direction: row;
@@ -102,12 +167,6 @@
     margin-top: 10px;
 }
 
-#exportAsCsv {
-    position: absolute;
-    top: 10px;
-    right: 20px;
-}
-
 .excludeFromExpeditionButton {
     position: absolute;
     right: 4px;
@@ -206,6 +265,87 @@
     height: 18px;
 }
 
+.stats {
+    margin-top: 10px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    flex-wrap: wrap;
+    justify-content: space-between;
+}
+
+.stats .statsGroup {
+    flex-grow: 1;
+    width: 100%;
+    max-width: 180px;
+    text-align: center;
+}
+
+.stats table {
+    font-size: 1em;
+    margin: 0 auto;
+}
+
+.stats table .itemType {
+    width: 25px;
+    text-align: center;
+}
+
+.stats table .itemType img {
+    height: 18px;
+    margin: 1px 4px;
+}
+.stats table .value,
+.stats table .separator,
+.stats table .total,
+.stats table .number {
+    text-align: right;
+}
+
+.stats table .separator {
+    width: 20px;
+}
+
+.stats table .value,
+.stats table .total {
+    width: 30px;
+}
+
+.stats table .number {
+    color: #808080;
+    font-size: 0.9em;
+    width: 50px;
+}
+
+a#exportLinks {
+    position: absolute;
+    top: 15px;
+    left: 320px;
+    z-index: 1;
+    margin-left: 10px;
+    padding: 4px 6px;
+    border: 1px solid #c8c8c8;
+    background: #f7f7f7;
+    border-radius: 4px;
+    white-space: nowrap;
+}
+
+a#exportLinks:hover {
+    border: 1px solid #808080;
+    background: #f0f0f0;
+    text-decoration: none;
+}
+
+@media (min-width: 991px) {
+    
+    .stats .statsGroup.statsGroupMateria {
+        border-bottom: 1px solid #f0f0f0;
+        padding-bottom: 5px;
+        margin-bottom: 5px;
+    }
+
+}
+
 @media (max-width: 991px) {
     .farmable .farmedButton {
         display: block;
@@ -225,5 +365,61 @@
     
     .itemWorldButton {
         display: block;
+    }
+    
+    .itemsWrapper {
+        display: block;
+    }
+
+    .itemsSidebar {
+        width: auto;
+    }
+
+    .itemsSidebar .itemsSidebarButton {
+        margin: 5px 0 15px 0;
+    }
+    
+    .itemsSidebar .itemsSidebarButton .glyphicon {
+        transform: rotate(90deg);
+    }
+
+    .itemsSidebar.collapsed {
+        width: auto;
+    }
+
+    .itemsSidebar.collapsed .toggle.btn .collapsedHidden,
+    .itemsSidebar.collapsed .itemsSidebarButton .collapsedHidden {
+        display: inline;
+    }
+
+    .itemsSidebar.collapsed .itemsSidebarButton .glyphicon {
+        transform: rotate(-90deg);
+    }
+
+    .stats {
+        margin-top: 0;
+        margin-bottom: 20px;
+        flex-direction: row;
+    }
+
+    .stats .statsGroup {
+        padding: 0 4px;
+    }
+}
+
+@media (max-width: 500px) {
+    a#exportLinks {
+        display: inline-block;
+        position: relative;
+        top: 0;
+        left: 0;
+        margin-left:10px;
+        margin-bottom:10px;
+    }
+}
+
+@media (max-width: 380px) {
+    .stats {
+        justify-content: center;
     }
 }

--- a/static/inventory.css
+++ b/static/inventory.css
@@ -227,7 +227,7 @@
 .typeJumpList {
     margin: 20px auto 0 auto;
     padding: 0 10px;
-    max-width: 70%;
+    max-width: 80%;
     font-size: 0.9em;
     clear: both;
 
@@ -405,6 +405,10 @@ a#exportLinks:hover {
     .stats .statsGroup {
         padding: 0 4px;
     }
+    
+    .typeJumpList {
+        max-width: 90%;
+    }
 }
 
 @media (max-width: 500px) {
@@ -415,6 +419,13 @@ a#exportLinks:hover {
         left: 0;
         margin-left:10px;
         margin-bottom:10px;
+    }
+    
+    .typeJumpList {
+        max-width: none;
+        padding: 0;
+        margin: 0;
+        margin-right: 5px;
     }
 }
 

--- a/static/inventory.css
+++ b/static/inventory.css
@@ -227,7 +227,6 @@
 .typeJumpList {
     margin: 20px auto 0 auto;
     padding: 0 10px;
-    max-width: 80%;
     font-size: 0.9em;
     clear: both;
 
@@ -405,10 +404,6 @@ a#exportLinks:hover {
     .stats .statsGroup {
         padding: 0 4px;
     }
-    
-    .typeJumpList {
-        max-width: 90%;
-    }
 }
 
 @media (max-width: 500px) {
@@ -422,7 +417,6 @@ a#exportLinks:hover {
     }
     
     .typeJumpList {
-        max-width: none;
         padding: 0;
         margin: 0;
         margin-right: 5px;

--- a/static/inventory.html
+++ b/static/inventory.html
@@ -1,6 +1,11 @@
 <html lang="en">
     <head>
-		<meta charset="UTF-8">
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+
+        <title>FFBE Equip : Inventory</title>
+        <link rel="icon" type="image/png" href="/img/heavyArmor.png">
+
         <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" 
               integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
 		<link rel="stylesheet" type="text/css" href="common.css?version=3">
@@ -8,8 +13,6 @@
         <link rel="stylesheet" type="text/css" href="languages.css">
         <link rel="stylesheet" type="text/css" href="https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css"
               integrity="sha384-xewr6kSkq3dBbEtB6Z/3oFZmknWn7nHqhLVLrYgzEFRbU/DHSxW7K3B44yWUN60D" crossorigin="anonymous">
-        <link rel="icon" type="image/png" href="/img/heavyArmor.png">
-        <title>FFBE Equip : Inventory</title>
     </head>
     <body>
         <a href="#" id="scrollToTopButton" style="display: none;" title="Scroll back to the top"><span></span></a>

--- a/static/inventory.html
+++ b/static/inventory.html
@@ -72,44 +72,295 @@
                 </nav>
             </div>
 
-            <div  class="col-xs-12 col-lg-8 col-lg-offset-2">
-                <span id="pleaseWaitMessage" class="h4">Please wait for your inventory to be loaded</span>
-                <span id="loginMessage" class="h4 hidden">Log-in to display your inventory</span>
-                <div id="inventory" class="hidden">
-                    <ul class="nav nav-tabs">
-                        <li class="equipment"  onclick="showEquipments()"><a><img src="img/equipment.png"/></a></li>
-                        <li class="materia" onclick="showMateria()"><a><img src="img/materia.png"/></a></li>
-                        <li class="history" onclick="showHistory()"><a><img src="img/history.png"/></a></li>
-                        <li class="settings" onclick="showSettings()"><a><img src="img/settings.png" /></a></li>
-                    </ul>
-                    <div id="tabsRightData"><span id="sortType"></span><span id="itemCount"></span><span id="materiaCount"></span></div>
-                    <a id="exportAsCsv" class="link" onclick="exportAsCsv()"><span class="glyphicon glyphicon-list"></span> Export as CSV</a>
-                    <div class="result-tab-pane">
-                        <div class="panel-body" style="padding:0;">
-                            <div class="col-xs-12">
-                                <input id="searchBox" type="text" class="form-control" placeholder="Enter item name or name of TMR's unit"/>
-                            </div>
-                            <div id="results" class="">
+            <div class="itemsWrapper">
+                <div class="itemsSidebar">
+                    <button class="itemsSidebarButton hidden" title="Toggle sidebar">
+                        <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
+                        <span class="collapsedHidden">Toggle stats</span>
+                    </button>
+                    <div class="stats hidden collapsedHidden">
+                        <div class="statsGroup statsGroupMateria">
+                            <table class="stats_materia"><tbody><tr>
+                                <td class="itemType"><img src="img/materia.png"/></td>
+                                <td class="value"></td>
+                                <td class="separator">/</td>
+                                <td class="total"></td>
+                                <td class="number"></td>
+                            </tr></tbody></table>
+                        </div>
+                        <div class="statsGroup">
+                            <table class="stats_dagger"><tbody><tr>
+                                <td class="itemType"><img src="img/dagger.png"/></td>
+                                <td class="value"></td>
+                                <td class="separator">/</td>
+                                <td class="total"></td>
+                                <td class="number"></td>
+                            </tr></tbody></table>
+                        </div>
+                        <div class="statsGroup">
+                            <table class="stats_sword"><tbody><tr>
+                                <td class="itemType"><img src="img/sword.png"/></td>
+                                <td class="value"></td>
+                                <td class="separator">/</td>
+                                <td class="total"></td>
+                                <td class="number"></td>
+                            </tr></tbody></table>
+                        </div>
+                        <div class="statsGroup">
+                            <table class="stats_greatSword"><tbody><tr>
+                                <td class="itemType"><img src="img/greatSword.png"/></td>
+                                <td class="value"></td>
+                                <td class="separator">/</td>
+                                <td class="total"></td>
+                                <td class="number"></td>
+                            </tr></tbody></table>
+                        </div>
+                        <div class="statsGroup">
+                            <table class="stats_katana"><tbody><tr>
+                                <td class="itemType"><img src="img/katana.png"/></td>
+                                <td class="value"></td>
+                                <td class="separator">/</td>
+                                <td class="total"></td>
+                                <td class="number"></td>
+                            </tr></tbody></table>
+                        </div>
+                        <div class="statsGroup">
+                            <table class="stats_staff"><tbody><tr>
+                                <td class="itemType"><img src="img/staff.png"/></td>
+                                <td class="value"></td>
+                                <td class="separator">/</td>
+                                <td class="total"></td>
+                                <td class="number"></td>
+                            </tr></tbody></table>
+                        </div>
+                        <div class="statsGroup">
+                            <table class="stats_rod"><tbody><tr>
+                                <td class="itemType"><img src="img/rod.png"/></td>
+                                <td class="value"></td>
+                                <td class="separator">/</td>
+                                <td class="total"></td>
+                                <td class="number"></td>
+                            </tr></tbody></table>
+                        </div>
+                        <div class="statsGroup">
+                            <table class="stats_bow"><tbody><tr>
+                                <td class="itemType"><img src="img/bow.png"/></td>
+                                <td class="value"></td>
+                                <td class="separator">/</td>
+                                <td class="total"></td>
+                                <td class="number"></td>
+                            </tr></tbody></table>
+                        </div>
+                        <div class="statsGroup">
+                            <table class="stats_axe"><tbody><tr>
+                                <td class="itemType"><img src="img/axe.png"/></td>
+                                <td class="value"></td>
+                                <td class="separator">/</td>
+                                <td class="total"></td>
+                                <td class="number"></td>
+                            </tr></tbody></table>
+                        </div>
+                        <div class="statsGroup">
+                            <table class="stats_hammer"><tbody><tr>
+                                <td class="itemType"><img src="img/hammer.png"/></td>
+                                <td class="value"></td>
+                                <td class="separator">/</td>
+                                <td class="total"></td>
+                                <td class="number"></td>
+                            </tr></tbody></table>
+                        </div>
+                        <div class="statsGroup">
+                            <table class="stats_spear"><tbody><tr>
+                                <td class="itemType"><img src="img/spear.png"/></td>
+                                <td class="value"></td>
+                                <td class="separator">/</td>
+                                <td class="total"></td>
+                                <td class="number"></td>
+                            </tr></tbody></table>
+                        </div>
+                        <div class="statsGroup">
+                            <table class="stats_harp"><tbody><tr>
+                                <td class="itemType"><img src="img/harp.png"/></td>
+                                <td class="value"></td>
+                                <td class="separator">/</td>
+                                <td class="total"></td>
+                                <td class="number"></td>
+                            </tr></tbody></table>
+                        </div>
+                        <div class="statsGroup">
+                            <table class="stats_whip"><tbody><tr>
+                                <td class="itemType"><img src="img/whip.png"/></td>
+                                <td class="value"></td>
+                                <td class="separator">/</td>
+                                <td class="total"></td>
+                                <td class="number"></td>
+                            </tr></tbody></table>
+                        </div>
+                        <div class="statsGroup">
+                            <table class="stats_throwing"><tbody><tr>
+                                <td class="itemType"><img src="img/throwing.png"/></td>
+                                <td class="value"></td>
+                                <td class="separator">/</td>
+                                <td class="total"></td>
+                                <td class="number"></td>
+                            </tr></tbody></table>
+                        </div>
+                        <div class="statsGroup">
+                            <table class="stats_gun"><tbody><tr>
+                                <td class="itemType"><img src="img/gun.png"/></td>
+                                <td class="value"></td>
+                                <td class="separator">/</td>
+                                <td class="total"></td>
+                                <td class="number"></td>
+                            </tr></tbody></table>
+                        </div>
+                        <div class="statsGroup">
+                            <table class="stats_mace"><tbody><tr>
+                                <td class="itemType"><img src="img/mace.png"/></td>
+                                <td class="value"></td>
+                                <td class="separator">/</td>
+                                <td class="total"></td>
+                                <td class="number"></td>
+                            </tr></tbody></table>
+                        </div>
+                        <div class="statsGroup">
+                            <table class="stats_fist"><tbody><tr>
+                                <td class="itemType"><img src="img/fist.png"/></td>
+                                <td class="value"></td>
+                                <td class="separator">/</td>
+                                <td class="total"></td>
+                                <td class="number"></td>
+                            </tr></tbody></table>
+                        </div>
+                        <div class="statsGroup">
+                            <table class="stats_lightShield"><tbody><tr>
+                                <td class="itemType"><img src="img/lightShield.png"/></td>
+                                <td class="value"></td>
+                                <td class="separator">/</td>
+                                <td class="total"></td>
+                                <td class="number"></td>
+                            </tr></tbody></table>
+                        </div>
+                        <div class="statsGroup">
+                            <table class="stats_heavyShield"><tbody><tr>
+                                <td class="itemType"><img src="img/heavyShield.png"/></td>
+                                <td class="value"></td>
+                                <td class="separator">/</td>
+                                <td class="total"></td>
+                                <td class="number"></td>
+                            </tr></tbody></table>
+                        </div>
+                        <div class="statsGroup">
+                            <table class="stats_hat"><tbody><tr>
+                                <td class="itemType"><img src="img/hat.png"/></td>
+                                <td class="value"></td>
+                                <td class="separator">/</td>
+                                <td class="total"></td>
+                                <td class="number"></td>
+                            </tr></tbody></table>
+                        </div>
+                        <div class="statsGroup">
+                            <table class="stats_helm"><tbody><tr>
+                                <td class="itemType"><img src="img/helm.png"/></td>
+                                <td class="value"></td>
+                                <td class="separator">/</td>
+                                <td class="total"></td>
+                                <td class="number"></td>
+                            </tr></tbody></table>
+                        </div>
+                        <div class="statsGroup">
+                            <table class="stats_clothes"><tbody><tr>
+                                <td class="itemType"><img src="img/clothes.png"/></td>
+                                <td class="value"></td>
+                                <td class="separator">/</td>
+                                <td class="total"></td>
+                                <td class="number"></td>
+                            </tr></tbody></table>
+                        </div>
+                        <div class="statsGroup">
+                            <table class="stats_lightArmor"><tbody><tr>
+                                <td class="itemType"><img src="img/lightArmor.png"/></td>
+                                <td class="value"></td>
+                                <td class="separator">/</td>
+                                <td class="total"></td>
+                                <td class="number"></td>
+                            </tr></tbody></table>
+                        </div>
+                        <div class="statsGroup">
+                            <table class="stats_heavyArmor"><tbody><tr>
+                                <td class="itemType"><img src="img/heavyArmor.png"/></td>
+                                <td class="value"></td>
+                                <td class="separator">/</td>
+                                <td class="total"></td>
+                                <td class="number"></td>
+                            </tr></tbody></table>
+                        </div>
+                        <div class="statsGroup">
+                            <table class="stats_robe"><tbody><tr>
+                                <td class="itemType"><img src="img/robe.png"/></td>
+                                <td class="value"></td>
+                                <td class="separator">/</td>
+                                <td class="total"></td>
+                                <td class="number"></td>
+                            </tr></tbody></table>
+                        </div>
+                        <div class="statsGroup">
+                            <table class="stats_accessory"><tbody><tr>
+                                <td class="itemType"><img src="img/accessory.png"/></td>
+                                <td class="value"></td>
+                                <td class="separator">/</td>
+                                <td class="total"></td>
+                                <td class="number"></td>
+                            </tr></tbody></table>
+                        </div>
+                    </div>
+                </div>
+                <div class="itemsContent">
+                    <span id="pleaseWaitMessage" class="h4">Please wait for your inventory to be loaded</span>
+                    <span id="loginMessage" class="h4 hidden">Log-in to display your inventory</span>
+                    <div id="inventory" class="hidden">
+                        <a id="exportLinks" class="link" onclick="exportAsCsv()">
+                            <span class="glyphicon glyphicon-share-alt"></span>
+                            Export as CSV
+                        </a>
+                        <ul class="nav nav-tabs">
+                            <li class="equipment"  onclick="showEquipments()"><a><img src="img/equipment.png"/></a></li>
+                            <li class="materia" onclick="showMateria()"><a><img src="img/materia.png"/></a></li>
+                            <li class="history" onclick="showHistory()"><a><img src="img/history.png"/></a></li>
+                            <li class="settings" onclick="showSettings()"><a><img src="img/settings.png" /></a></li>
+                        </ul>
+                        <div id="tabsRightData">
+                            <span id="sortType"></span>
+                            <span id="itemCount"></span>
+                            <span id="materiaCount"></span>
+                        </div>
+                        <div class="result-tab-pane">
+                            <div class="panel-body" style="padding:0;">
+                                <div class="col-xs-12">
+                                    <input id="searchBox" type="text" class="form-control" placeholder="Enter item name or name of TMR's unit"/>
+                                </div>
+                                <div id="results" class="">
 
-                            </div>
-                            <div id="itemEnhancement" class="hidden">
+                                </div>
+                                <div id="itemEnhancement" class="hidden">
+                                </div>
                             </div>
                         </div>
                     </div>
                 </div>
-                <div class="footerButtons">
-                    <div>
-                        <a class="buttonLink" href="https://www.reddit.com/message/compose/?to=lyrgard" target="_blank" rel="noreferrer">Send me a message on reddit</a>
-                        <a class="buttonLink" href="https://discord.gg/rgXnjhP" target="_blank" rel="noreferrer">Chat on FFBE Equip discord server</a>
-                        <a class="buttonLink" href="https://github.com/lyrgard/ffbeEquip" target="_blank" rel="noreferrer">See code on GitHub</a>
-                    </div>
-                    <div>
-                        <a class="buttonLink" href='https://ko-fi.com/Lyrgard' target="_blank" rel="noreferrer">Buy me a coffee</a>
-                        <a class="buttonLink" href='https://www.patreon.com/Lyrgard' target="_blank" rel="noreferrer">Become my patron on Patreon</a>
-                    </div>
-                    <div>
-                        <a class="buttonLink" data-server="JP" href='https://exviusdb.com/' target="_blank" rel="noreferrer">JP units and items images are a courtesy of EXVIUS DB</a>
-                    </div>
+            </div>
+            <div class="footerButtons">
+                <div>
+                    <a class="buttonLink" href="https://www.reddit.com/message/compose/?to=lyrgard" target="_blank" rel="noreferrer">Send me a message on reddit</a>
+                    <a class="buttonLink" href="https://discord.gg/rgXnjhP" target="_blank" rel="noreferrer">Chat on FFBE Equip discord server</a>
+                    <a class="buttonLink" href="https://github.com/lyrgard/ffbeEquip" target="_blank" rel="noreferrer">See code on GitHub</a>
+                </div>
+                <div>
+                    <a class="buttonLink" href='https://ko-fi.com/Lyrgard' target="_blank" rel="noreferrer">Buy me a coffee</a>
+                    <a class="buttonLink" href='https://www.patreon.com/Lyrgard' target="_blank" rel="noreferrer">Become my patron on Patreon</a>
+                </div>
+                <div>
+                    <a class="buttonLink" data-server="JP" href='https://exviusdb.com/' target="_blank" rel="noreferrer">JP units and items images are a courtesy of EXVIUS DB</a>
                 </div>
             </div>
         </div>

--- a/static/units.css
+++ b/static/units.css
@@ -401,6 +401,7 @@
 
 .stats table .number {
     color: #808080;
+    font-size: 0.9em;
 }
 
 .unitName {
@@ -565,7 +566,7 @@
         position: relative;
         top: 0;
         left: 0;
-        margin: 10px 0;
+        margin-bottom:10px;
     }
     
     #exportLinks .text {

--- a/static/units.js
+++ b/static/units.js
@@ -980,6 +980,11 @@ function startPage() {
             $unitsSidebarInternal.css('width', $unitsSidebar.outerWidth() + 'px');
         }
     });
+    
+    // Start stats collapse for small screen
+    if ($window.outerWidth() < 990) {
+        $unitsSidebar.addClass("collapsed");
+    }
 
     $("#searchBox").on("input", $.debounce(300,updateResults));
     
@@ -993,6 +998,5 @@ function startPage() {
     $('#modeToggle').change(function() {
       $("#results").toggleClass("simpleMode");
     });
-
 }
     


### PR DESCRIPTION
After the Units page, the Inventory page!

Lots of improvements for small screen, and as a bonus add some stats (just like units).

**Screenshot of large screen:**
![image](https://user-images.githubusercontent.com/7137528/44001994-f1f1233a-9e3b-11e8-8f1d-a0a2daf80528.png)

**Screenshot of small screen:**
![image](https://user-images.githubusercontent.com/7137528/44002005-19886fc0-9e3c-11e8-88aa-64ce428b6b70.png)


Added: little improvements for Units page to autocollapse the stats when the screen is small (at loading time only).