### PR TITLE
Rework Espers page for small screen

### DIFF
--- a/static/espers.css
+++ b/static/espers.css
@@ -1,12 +1,56 @@
-#espers {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+
+#esper {
+    position:relative;
+    width: 100%;
+    margin: 0 auto;
 }
 
-#espers .result-tab-pane {
+#espers .tabsWrapper {
+    position:relative;
+    margin: 0 auto;
     width: 100%;
-    max-width: 1024px;
+    max-width: 1300px;
+    overflow: hidden;
+}
+
+#espers .tabsWrapper:before,
+#espers .tabsWrapper:after {
+    content: "";
+    position: absolute;
+    top: 0;
+    height: 100%;
+    width: 50px;
+    z-index: 1;
+    pointer-events: none;
+}
+#espers .tabsWrapper:before {
+    left: 0;
+    background: linear-gradient(to right,#ffffff,rgba(248,247,238,0));
+}
+#espers .tabsWrapper:after {
+    right: 0;
+    background: linear-gradient(to left,#ffffff,rgba(248,247,238,0));
+}
+
+#espers #tabs {
+    display: flex;
+    justify-content: space-between;
+    overflow-x: auto;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+    -ms-overflow-style: -ms-autohiding-scrollbar;
+}
+
+#espers #tabs li {
+    cursor: pointer;
+}
+
+#espers #tabs li:first-child {
+    padding-left: 30px;
+}
+
+#espers #tabs li:last-child {
+    padding-right: 30px;
 }
 
 #espers #tabs img {
@@ -34,9 +78,54 @@
     border-color: white;
 }
 
+#panWrapper {
+    overflow: auto;
+    padding: 8px;
+}
+
+#gridTrimmer {
+    overflow: hidden;
+    margin: 0 auto;
+}
+
+#gridTrimmer.star1 {
+    width:540px;
+    height:470px;
+}
+
+#gridTrimmer.star1 #gridContainer {
+    margin-left: -180px;
+    margin-top: -170px;
+}
+
+#gridTrimmer.star2 {
+    width:740px;
+    height:660px;
+}
+
+#gridTrimmer.star2 #gridContainer {
+    margin-left: -90px;
+    margin-top: -80px;
+}
+
+#gridTrimmer.star3 {
+    width:940px;
+    height:860px;
+}
+
+#gridTrimmer.star3 #gridContainer {
+    margin-left: 10px;
+    margin-top: 20px;
+}
+
 #gridContainer {
     position: relative;
-    margin-right: -10%;
+    width:1000px;
+    height:1000px;
+}
+
+#grid {
+    overflow: hidden;
 }
 
 #grid li {
@@ -130,7 +219,9 @@
   margin: 0 1%;
 }
 
-#grid li:nth-child(18n+10), #grid li:nth-child(18n+11), #grid li:nth-child(18n+12), #grid li:nth-child(18n+13), #grid li:nth-child(18n+14), #grid li:nth-child(18n+15), #grid li:nth-child(18n+16), #grid li:nth-child(18n+17), #grid li:nth-child(18n+18) {
+#grid li:nth-child(18n+10), #grid li:nth-child(18n+11), #grid li:nth-child(18n+12), 
+#grid li:nth-child(18n+13), #grid li:nth-child(18n+14), #grid li:nth-child(18n+15), 
+#grid li:nth-child(18n+16), #grid li:nth-child(18n+17), #grid li:nth-child(18n+18) {
     margin-top: -2%;
     margin-bottom: -2%;
     -o-transform: translateX(50%) rotate(-60deg) skewY(30deg);
@@ -166,16 +257,9 @@
     align-items: center;
 }
 
-#grid.star1 li .hexagon.star2, #grid.star1 li .hexagon.star3, #grid.star2 li .hexagon.star3, #grid.star1 li .hexagon.star2 *, #grid.star1 li .hexagon.star3 *, #grid.star2 li .hexagon.star3 * {
+#grid.star1 li .hexagon.star2, #grid.star1 li .hexagon.star3, #grid.star2 li .hexagon.star3, 
+#grid.star1 li .hexagon.star2 *, #grid.star1 li .hexagon.star3 *, #grid.star2 li .hexagon.star3 * {
     visibility: hidden;
-}
-
-#grid.star1 {
-    margin-top: -17%
-}
-
-#grid.star2 {
-    margin-top: -8.5%
 }
 
 .line {
@@ -244,12 +328,15 @@
 .esperHeader {
     display: flex;
     flex-direction: row;
+    justify-content: space-around;
+    flex-wrap: wrap;
     margin-top: 10px;
-    justify-content: space-between;
+    padding-right: 30px;
+    min-height: 150px;
 }
 
 .esperChoice {
-    width: 400px;
+    min-width: 280px;
 }
 
 .formGroup {
@@ -263,8 +350,7 @@
 }
 
 .formLabel {
-    width: 100px;
-    min-width: 100px;
+    min-width: 75px;
     line-height: 34px;
     text-align: right;
     padding-right: 5px;
@@ -275,13 +361,67 @@
     padding-left: 5px;
 }
 
-.formLine.stats .formGroup {
-    width: 150px;
+.formValue .statsBonus {
+    color: #19983d;
 }
 
 .esperOtherStats {
-    width: 200px;
     position: relative;
+    padding-left: 40px;
+    padding-bottom: 15px;
+}
+
+.esperOtherStats .esperSkills {
+    position: absolute;
+    top: 65px;
+}
+
+.shareLink a {
+    display: inline-block;
+    margin: 0 auto 15px auto;
+    padding: 4px 6px;
+    border: 1px solid #c8c8c8;
+    background: #f7f7f7;
+    border-radius: 4px;
+    white-space: nowrap;
+}
+
+.shareLink a:hover {
+    border: 1px solid #808080;
+    background: #f0f0f0;
+    text-decoration: none;
+}
+
+.error {
+    font-weight: bold;
+    color: red;
+}
+.formGroup {
+    display: flex;
+    flex-direction: column;
+}
+
+.formLine {
+    display: flex;
+    flex-direction: row;
+}
+
+.formLabel {
+    min-width: 75px;
+    line-height: 34px;
+    text-align: right;
+    padding-right: 5px;
+}
+
+.formValue {
+    line-height: 34px;
+    padding-left: 5px;
+}
+
+.esperOtherStats {
+    position: relative;
+    padding-left: 40px;
+    padding-bottom: 15px;
 }
 
 .esperOtherStats .esperSkills {
@@ -301,3 +441,106 @@
     font-weight: bold;
     color: red;
 }
+
+#spFixed {
+    display: none;
+    position: fixed;
+    left: 10px;
+    bottom: 20px;
+    opacity: 0.5;
+    z-index: 9999;
+    background-color: #052464;
+    color: white;
+    padding: 5px 10px;
+    border-radius: 5px;
+    font-size: 1.1em;
+    cursor: help;
+}
+
+#spFixed:hover {
+    opacity: 1;
+}
+
+#spFixed .name {
+    font-weight: bold;
+}
+
+#toggleGrid {
+    display: none;
+    position: fixed;
+    right: 10px;
+    bottom: 10px;
+    cursor: pointer;
+    width: 75px;
+    height: 75px;
+    border-radius: 75px;
+    background-color: #052464;
+    opacity: 0.5;
+    z-index: 9999;
+}
+
+#toggleGrid:hover {
+    opacity: 1;
+}
+
+#toggleGrid span {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    color: white;
+    font-size: 30px;
+    margin-left: -13px;
+    margin-top: -14px;
+}
+
+@media (max-width: 990px) {
+    
+    #esper #panWrapper {
+        box-shadow: inset 0 1px 5px #00000040;
+    }
+}
+
+@media (max-height: 700px) {
+    #toggleGrid {
+        display: block;
+    }
+    
+    #esper #panWrapper {
+        position: absolute;
+        top: -100000px;
+        left: -100000px;
+    }
+
+    #esper.viewingTrainingGrid .esperHeader,
+    #esper.viewingTrainingGrid .shareLink {
+        display: none;
+    }
+
+    #esper.viewingTrainingGrid #panWrapper {
+        position: relative;
+        top: 0;
+        left: 0;
+    }
+}
+
+@media (max-height: 700px) and (min-width: 920px) {
+    #panWrapper.star1,
+    #panWrapper.star2,
+    #panWrapper.star3 {
+        overflow-x: hidden;
+    }
+}
+
+@media (max-height: 700px) and (min-width: 720px) {
+    #panWrapper.star1,
+    #panWrapper.star2 {
+        overflow-x: hidden;
+    }
+}
+
+@media (max-height: 700px) and (min-width: 520px) {
+    #panWrapper.star1 {
+        overflow-x: hidden;
+    }
+}
+

--- a/static/espers.html
+++ b/static/espers.html
@@ -1,6 +1,11 @@
 <html lang="en">
     <head>
-		<meta charset="UTF-8">
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+
+        <title>FFBE Equip : Espers</title>
+        <link rel="icon" type="image/png" href="/img/heavyArmor.png">
+
         <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" 
               integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
 		<link rel="stylesheet" type="text/css" href="common.css?version=3">
@@ -8,11 +13,12 @@
         <link rel="stylesheet" type="text/css" href="languages.css">
         <link rel="stylesheet" type="text/css" href="https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css"
               integrity="sha384-xewr6kSkq3dBbEtB6Z/3oFZmknWn7nHqhLVLrYgzEFRbU/DHSxW7K3B44yWUN60D" crossorigin="anonymous">
-        <link rel="icon" type="image/png" href="/img/heavyArmor.png">
-        <title>FFBE Equip : Espers</title>
     </head>
     <body>
-        <a href="#" id="scrollToTopButton" style="display: none;" title="Scroll back to the top"><span></span></a>
+        <a href="#" id="toggleGrid" class="hidden" title="Toggle Esper training grid">
+            <span class="glyphicon glyphicon-th"></span>
+            <span class="glyphicon glyphicon-list hidden"></span>
+        </a>
         <div id="loaderGlassPanel" class="hidden">
             <div id="loader"></div>
         </div>
@@ -74,73 +80,81 @@
                     
                 </nav>
             </div>
-
-            <div  class="col-xs-12">
-
+            <div class="" style="clear: both">
                 <span id="pleaseWaitMessage" class="h4">Please wait for your espers to be loaded</span>
                 <span id="loginMessage" class="h4 hidden">Log-in to display your espers</span>
-                <div id="notLoginWarningMessage" class="h5 hidden"><span class="glyphicon glyphicon-alert" style="margin-right:10px"></span>You are not logged in. Changes made won't be saved</div>
+                <div id="notLoginWarningMessage" class="h5 hidden">
+                    <span class="glyphicon glyphicon-alert" style="margin-right:10px"></span>You are not logged in. Changes made won't be saved
+                </div>
                 <div id="espers" class="hidden">
-                    <ul id="tabs" class="nav nav-tabs">
-                    </ul>
-                    <div class="result-tab-pane">
-                        <div class="panel-body" style="padding:0;">
-                            <div id="esper">
-                                <div class="esperHeader">
-                                    <div class="formGroup esperChoice">
-                                        <div class="formLine">
-                                            <label  for="esperStar" class="formLabel">Rarity</label>
-                                            <select id="esperStar" class="form-control formInput"></select>
-                                        </div>
+                    <div class="tabsWrapper">
+                        <ul id="tabs" class="nav nav-tabs"></ul>
+                    </div>
+                    <div id="esper">
+                        <div class="esperHeader">
+                            <div class="formGroup esperChoice">
+                                <div class="formLine">
+                                    <label for="esperStar" class="formLabel">Rarity</label>
+                                    <select id="esperStar" class="form-control formInput"></select>
+                                </div>
 
-                                        <div class="formLine levelLine">
-                                            <label  for="level" class="formLabel">Level</label>
-                                            <input id="level" type="number" class="form-control formInput"/>
-                                        </div>
-                                            
-                                        <div class="formLine spLine">
-                                            <label  for="sp" class="formLabel">SP</label>
-                                            <span id="sp" class="formValue"></span> 
-                                        </div>
+                                <div class="formLine levelLine">
+                                    <label for="level" class="formLabel">Level</label>
+                                    <input id="level" type="number" class="form-control formInput"/>
+                                </div>
+                                    
+                                <div class="formLine spLine">
+                                    <label for="sp" class="formLabel">SP</label>
+                                    <span id="sp" class="formValue spUsed"></span> 
+                                </div>
+                            </div>
+                            <div class="formLine stats invisible">
+                                <div class="formGroup">
+                                    <div class="formLine">
+                                        <label class="formLabel">HP</label>
+                                        <span id="esper_hp" class="formValue"></span> 
                                     </div>
-                                    <div class="formLine stats invisible">
-                                        <div class="formGroup">
-                                            <div class="formLine">
-                                                <label class="formLabel">HP</label>
-                                                <span id="esper_hp" class="formValue"></span> 
-                                            </div>
-                                            <div class="formLine">
-                                                <label class="formLabel">ATK</label>
-                                                <span id="esper_atk" class="formValue"></span> 
-                                            </div>
-                                            <div class="formLine">
-                                                <label class="formLabel">MAG</label>
-                                                <span id="esper_mag" class="formValue"></span>
-                                            </div>
-                                        </div>
-                                        <div class="formGroup">
-                                            <div class="formLine">
-                                                <label class="formLabel">MP</label>
-                                                <span id="esper_mp" class="formValue"></span> 
-                                            </div>
-                                            <div class="formLine">
-                                                <label class="formLabel">DEF</label>
-                                                <span id="esper_def" class="formValue"></span>  
-                                            </div>
-                                            <div class="formLine">
-                                                <label class="formLabel">SPR</label>
-                                                <span id="esper_spr" class="formValue"></span> 
-                                            </div>
-                                        </div>
+                                    <div class="formLine">
+                                        <label class="formLabel">ATK</label>
+                                        <span id="esper_atk" class="formValue"></span> 
                                     </div>
-                                    <div class="formGroup esperOtherStats invisible">
-                                        <span id="esperResist" class="formLine"></span>                                            
-                                        <span id="esperSkills" class="formLine"></span> 
+                                    <div class="formLine">
+                                        <label class="formLabel">MAG</label>
+                                        <span id="esper_mag" class="formValue"></span>
                                     </div>
                                 </div>
-                                <div class="formLine shareLink">
-                                    <a onclick="getPublicEsperLink()"><span class="glyphicon glyphicon-link"></span> share this esper</a>
+                                <div class="formGroup">
+                                    <div class="formLine">
+                                        <label class="formLabel">MP</label>
+                                        <span id="esper_mp" class="formValue"></span> 
+                                    </div>
+                                    <div class="formLine">
+                                        <label class="formLabel">DEF</label>
+                                        <span id="esper_def" class="formValue"></span>  
+                                    </div>
+                                    <div class="formLine">
+                                        <label class="formLabel">SPR</label>
+                                        <span id="esper_spr" class="formValue"></span> 
+                                    </div>
                                 </div>
+                            </div>
+                            <div class="formGroup esperOtherStats invisible">
+                                <span id="esperResist" class="formLine"></span>                                            
+                                <span id="esperSkills" class="formLine"></span> 
+                            </div>
+                        </div>
+                        <div class="formLine shareLink">
+                            <a onclick="getPublicEsperLink()">
+                                <span class="glyphicon glyphicon-link"></span> 
+                                Get a link to this Esper build
+                            </a>
+                        </div>
+                        <div id="panWrapper">
+                            <div id="spFixed">
+                                <span class="name">SP</span>
+                                <span class="spUsed"></span> 
+                            </div>
+                            <div id="gridTrimmer">
                                 <div id="gridContainer">
                                     <ul id="grid" class="clear">
                                     </ul>
@@ -149,20 +163,20 @@
                         </div>
                     </div>
                 </div>
-                <div class="footerButtons">
-                    <div>
-                        <a class="buttonLink" href="https://www.reddit.com/message/compose/?to=lyrgard" target="_blank" rel="noreferrer">Send me a message on reddit</a>
-                        <a class="buttonLink" href="https://discord.gg/rgXnjhP" target="_blank" rel="noreferrer">Chat on FFBE Equip discord server</a>
-                        <a class="buttonLink" href="https://github.com/lyrgard/ffbeEquip" target="_blank" rel="noreferrer">See code on GitHub</a>
-                    </div>
-                    <div>
-                        <a class="buttonLink" href='https://ko-fi.com/Lyrgard' target="_blank" rel="noreferrer">Buy me a coffee</a>
-                        <a class="buttonLink" href='https://www.patreon.com/Lyrgard' target="_blank" rel="noreferrer">Become my patron on Patreon</a>
-                    </div>
-                    <div>
-                        <a class="buttonLink" data-server="JP" href='https://exviusdb.com/' target="_blank" rel="noreferrer">JP units and items images are a courtesy of EXVIUS DB</a>
-                    </div>
-                </div>
+            </div>
+        </div>
+        <div class="footerButtons">
+            <div>
+                <a class="buttonLink" href="https://www.reddit.com/message/compose/?to=lyrgard" target="_blank" rel="noreferrer">Send me a message on reddit</a>
+                <a class="buttonLink" href="https://discord.gg/rgXnjhP" target="_blank" rel="noreferrer">Chat on FFBE Equip discord server</a>
+                <a class="buttonLink" href="https://github.com/lyrgard/ffbeEquip" target="_blank" rel="noreferrer">See code on GitHub</a>
+            </div>
+            <div>
+                <a class="buttonLink" href='https://ko-fi.com/Lyrgard' target="_blank" rel="noreferrer">Buy me a coffee</a>
+                <a class="buttonLink" href='https://www.patreon.com/Lyrgard' target="_blank" rel="noreferrer">Become my patron on Patreon</a>
+            </div>
+            <div>
+                <a class="buttonLink" data-server="JP" href='https://exviusdb.com/' target="_blank" rel="noreferrer">JP units and items images are a courtesy of EXVIUS DB</a>
             </div>
         </div>
         <script src="https://code.jquery.com/jquery-3.1.0.min.js" 


### PR DESCRIPTION
Reworked Espers page for small screen.

Wow, this one was tricky.

 1. For small screen, the stats and the board are separated in two views. You can switch between the views with the toggle button on the bottom right.
 2. The Esper selector at the top is now forced to a single line (to gain space)
 3. The link dialog now adapt to small screen
 4. A fixed label with the current SP counter is displayed at the bottom right if the first one is not visible

**Before:**
![image](https://user-images.githubusercontent.com/7137528/44054950-47706330-9f44-11e8-8d7c-7371ba93143b.png)

**After (stats view)**
![image](https://user-images.githubusercontent.com/7137528/44054968-57649626-9f44-11e8-9709-68da596581be.png)

**After (board view)**
![image](https://user-images.githubusercontent.com/7137528/44054989-63f8f666-9f44-11e8-9ff5-42dead41cb12.png)
