### PR TITLE
Enhance Espers page (again)

### DIFF
--- a/static/espers.css
+++ b/static/espers.css
@@ -120,9 +120,10 @@
 
 #gridContainer {
     position: relative;
-    width:1000px;
-    height:1000px;
-    transform-origin:50% 50%;
+    width: 1000px;
+    height: 1000px;
+    transform-origin: 50% 50%;
+    z-index: -1;
 }
 
 #grid {
@@ -504,19 +505,18 @@
     }
 }
 
-@media (max-width: 990px) {
-    
-    #esper #panWrapper {
-        box-shadow: inset 0 1px 5px #00000040;
-    }
-}
+@media (max-width: 768px), (pointer:coarse) and (hover:none) {
 
-@media (max-height: 700px) {
+    .container-fluid {
+        padding: 0;
+    }
+
     #toggleGrid {
         display: block;
     }
     
     #esper #panWrapper {
+        box-shadow: inset 0 2px 5px #00000050;
         position: absolute;
         top: -100000px;
         left: -100000px;
@@ -568,7 +568,7 @@
     }
 }
 
-@media (max-height: 700px) and (min-width: 650px) {
+@media (min-width: 650px) {
     #panWrapper.star1,
     #panWrapper.star2,
     #panWrapper.star3 {
@@ -576,14 +576,14 @@
     }
 }
 
-@media (max-height: 700px) and (min-width: 500px) {
+@media (min-width: 500px) {
     #panWrapper.star1,
     #panWrapper.star2 {
         overflow-x: hidden;
     }
 }
 
-@media (max-height: 700px) and (min-width: 360px) {
+@media (min-width: 360px) {
     #panWrapper.star1 {
         overflow-x: hidden;
     }

--- a/static/espers.js
+++ b/static/espers.js
@@ -827,6 +827,16 @@ function startPage() {
         } else {
             var $esper = $('#esper');
             var $pan = $esper.find('#panWrapper');
+            
+            if ($esper.hasClass('viewingTrainingGrid')) {
+                currentScrollTop = $pan.scrollTop();
+                currentScrollLeft = $pan.scrollLeft();
+                $('#spFixed').hide();
+                $('.tabsWrapper').show();
+            } else {
+                $('#spFixed').show();
+                $('.tabsWrapper').hide();
+            }
 
             // Define height with remaining space
             $pan.height($window.outerHeight() - $esper.offset().top - 15);
@@ -834,14 +844,6 @@ function startPage() {
             if (currentScrollTop === null || currentScrollLeft === null) {
                 setCurrentScrollToCenter($pan);
             } 
-            
-            if ($esper.hasClass('viewingTrainingGrid')) {
-                currentScrollTop = $pan.scrollTop();
-                currentScrollLeft = $pan.scrollLeft();
-                $('#spFixed').hide();
-            } else {
-                $('#spFixed').show();
-            }
             
             $esper.toggleClass('viewingTrainingGrid');
 


### PR DESCRIPTION

After discussion with @lyrgard, made some enhancement to avoid getting the toggle button on desktop.

On mobile, when toggling, the espers selector bar is now hidden as well, so we have even more space to display the grid!