### PR TITLE
Fix lazyload bug in inventory (item enhancement)

### DIFF
--- a/static/inventory.js
+++ b/static/inventory.js
@@ -175,7 +175,7 @@ function displayItemsByTypeAsync(items, start, div, id, jumpDiv) {
             setTimeout(displayItemsByTypeAsync, 0, items, index, div, id, jumpDiv);
         }
     }
-};
+}
 
 function displayItemsAsync(items, start, div, id, max = 20) {
     var html = '';
@@ -596,7 +596,7 @@ function showItemEnhancements(itemId) {
                 break;
             }
         }
-        if (!item) {return}
+        if (!item) { return; }
         currentEnhancementItem = item;
         var totalCount = itemInventory[itemId];
         var notEnchantedCount = totalCount;
@@ -626,6 +626,7 @@ function showItemEnhancements(itemId) {
         if (!popupAlreadyDisplayed && notEnchantedCount == totalCount) {
             modifyItemEnhancements(item.id);
         }
+        lazyLoader.update();
     }
 }
 


### PR DESCRIPTION

Fix a bug introduced by lazyloading.

When opening item management popup, image was not loading:
![image](https://user-images.githubusercontent.com/7137528/44257333-f7c4a600-a20b-11e8-8730-82f564872165.png)


Fixed:
![image](https://user-images.githubusercontent.com/7137528/44257359-0ad77600-a20c-11e8-9339-8b5ff886133c.png)
