### PR TITLE
Add HTML5 doctype

### DIFF
--- a/static/builder.html
+++ b/static/builder.html
@@ -1,5 +1,5 @@
 <!-- Doctype HTML5 -->
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
     <head>
         <meta charset="UTF-8">

--- a/static/builderHelp.html
+++ b/static/builderHelp.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
     <head>
 		<meta charset="UTF-8">

--- a/static/checkWebWorker.html
+++ b/static/checkWebWorker.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
     <head></head>
     <body>

--- a/static/contribute.html
+++ b/static/contribute.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
     <head>
         <meta charset="UTF-8">

--- a/static/espers.html
+++ b/static/espers.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
     <head>
         <meta charset="UTF-8">

--- a/static/index.html
+++ b/static/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
     <head>
         <meta charset="UTF-8">

--- a/static/inventory.html
+++ b/static/inventory.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
     <head>
         <meta charset="UTF-8">

--- a/static/unitSearch.html
+++ b/static/unitSearch.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
     <head>
         <meta charset="UTF-8">

--- a/static/units.html
+++ b/static/units.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
     <head>
         <meta charset="UTF-8">


### PR DESCRIPTION

As the title suggests...

HTML documents requires a doctype, as per the W3C spec.