### PR TITLE
Add help message for Units page for Simple/Edit Mode

### DIFF
--- a/static/common.css
+++ b/static/common.css
@@ -924,8 +924,11 @@ i.img.inline {
 @media (max-width: 768px) {
 
     .alert {
-        padding: 6px;
+        padding: 8px;
         margin-bottom: 10px; 
+    }
+    .alert-dismissable, .alert-dismissible {
+        padding-right: 28px;
     }
     .alert .glyphicon {
         margin-right: 6px;

--- a/static/units.html
+++ b/static/units.html
@@ -293,6 +293,27 @@
                                 <div class="col-xs-12">
                                     <input id="searchBox" type="text" class="form-control" placeholder="Enter unit name"/>
                                 </div>
+                                <div id="firstTimeMessage" class="col-xs-12 hidden">
+                                    <div class="alert alert-info alert-dismissible" role="alert">
+                                        <button type="button" class="close" data-dismiss="alert">&times;</button>
+                                        <p>
+                                            <span class="glyphicon glyphicon-info-sign"></span>
+                                            <strong>Hello! Is this your first time?</strong>
+                                        </p>
+                                        <p>
+                                            By default, units are displayed in <strong>Simple Mode</strong>, which means clicking on the unit will add it to your collection
+                                            (and clicking on the little Moogle on the top right corner will add one TMR).
+                                        </p>
+                                        <p>
+                                            Switching to <strong>Edit Mode</strong> will allow you to fully control your units and TMR numbers.
+                                        </p>
+                                        <p>
+                                            The switch is visible 
+                                            <span class="hidden-xs">at the bottom of the sidebar, on your left.</span>
+                                            <span class="hidden-sm hidden-md hidden-lg">at the bottom right of your screen.</span>
+                                        </p>
+                                    </div>
+                                </div>
                                 <div id="results" class="col-xs-12 simpleMode">
 
                                 </div>

--- a/static/units.js
+++ b/static/units.js
@@ -769,6 +769,10 @@ function updateResults() {
 
 function inventoryLoaded() {
     onDataReady();
+
+    if (Object.keys(ownedUnits).length === 0) {
+        $("#firstTimeMessage").removeClass('hidden');
+    }
 }
 
 function prepareData() {


### PR DESCRIPTION

After quite some feedbacks, it seems a lot of people are having issue with Simple/Edit mode.

This little PR aims to offer a little guidance for newcomers, by displaying a message in the Units page when there are no units in the collection.

### Desktop mode:
![image](https://user-images.githubusercontent.com/7137528/44547281-db000500-a71a-11e8-8842-44b042cdbd36.png)


### Mobile mode:
![image](https://user-images.githubusercontent.com/7137528/44547251-c91e6200-a71a-11e8-9486-7f9858d704ae.png)
