### PR TITLE
Fix Persistent goal marker not being reset for resists stats

### DIFF
--- a/static/builder.js
+++ b/static/builder.js
@@ -374,7 +374,7 @@ function logBuild(build, value) {
 
     //$("#buildResult").html(html);
 
-    $("#resultStats > div").removeClass("statToMaximize");
+    $("#resultStats .statToMaximize").removeClass("statToMaximize");
 
     var link = Piramidata.getImageLink(builds[currentUnitIndex]);
     $(".imageLink").prop("href",link);


### PR DESCRIPTION

Ok, this one is smallest to date!

Fixes #104 " Persistent goal marker over multiple units"

The jQuery selector was targeting only div right below the results stats, hence missing the resists divs.
We simply select all element with `statToMaximize` to remove it... 😸  Nice and easy!