### PR TITLE
Builder page: add clear items button

### DIFF
--- a/static/builder.css
+++ b/static/builder.css
@@ -699,6 +699,12 @@ i.img.img-slot-hand.leftHand {
     background-color: white;
 }
 
+.buildLinks {
+    display: flex;
+    align-items: center;
+    justify-content: space-evenly;
+}
+
 @media (max-width: 991px) {
     
     .panel.unit .panel-body {

--- a/static/builder.html
+++ b/static/builder.html
@@ -531,20 +531,59 @@
                                 <div class="resultLine healingResult hidden">Healing coef: <span class="calcValue"></span></div>
                             </div>
                             <div class="buildLinks hidden">
-                                <div id="detailedViewLink" class="col-xs-6 link text-center">
+                                <div id="detailedViewLink" class="link text-center">
                                     <a onclick="switchView(false);"><span class="glyphicon glyphicon-zoom-in"></span> Detailed View</a>
                                 </div>
-                                <div id="conciseViewLink" class="col-xs-6 hidden link text-center">
+                                <div id="conciseViewLink" class="hidden link text-center">
                                     <a onclick="switchView(true);"><span class="glyphicon glyphicon-zoom-out"></span> Concise View</a>
                                 </div>
-                                <div id="shareLinksMenu" class="col-xs-6 text-center ">
+                                <div id="shareLinksMenu" class="text-center">
                                     <div class="dropdown">
-                                        <a class=" dropdown-toggle link" type="button" data-toggle="dropdown"><span class="glyphicon glyphicon-share-alt"></span> Share this build<span class="caret"></span></a>
-                                        <ul class="dropdown-menu">
-                                            <li><a class="buildLink link" onclick="showBuildLink(true)"><span class="glyphicon glyphicon-link"></span> FFBE Equip link (this unit only)</a></li>
-                                            <li><a class="buildLink link" onclick="showBuildLink(false)"><span class="glyphicon glyphicon-link"></span> FFBE Equip link (all units)</a></li>
-                                            <li><a class="buildAsText link" onclick="showBuildAsText()"><span class="glyphicon glyphicon-list"></span> Build as text</a></li>
-                                            <li data-server="GL"><a class="imageLink link" target="_blank" rel="noreferrer"><span class="glyphicon glyphicon-camera"></span> Build image (using kupoconfig.com)</a></li>
+                                        <a class=" dropdown-toggle link" type="button" data-toggle="dropdown">
+                                            <span class="glyphicon glyphicon-share-alt"></span> 
+                                            Share <span class='hidden-xs'>this build</span> <span class="caret"></span>
+                                        </a>
+                                        <ul class="dropdown-menu dropdown-menu-right">
+                                            <li>
+                                                <a class="buildLink link" onclick="showBuildLink(true)">
+                                                    <span class="glyphicon glyphicon-link"></span> FFBE Equip link (this unit only)
+                                                </a>
+                                            </li>
+                                            <li>
+                                                <a class="buildLink link" onclick="showBuildLink(false)">
+                                                    <span class="glyphicon glyphicon-link"></span> FFBE Equip link (all units)
+                                                </a>
+                                            </li>
+                                            <li>
+                                                <a class="buildAsText link" onclick="showBuildAsText()">
+                                                    <span class="glyphicon glyphicon-list"></span> Build as text
+                                                </a>
+                                            </li>
+                                            <li data-server="GL">
+                                                <a class="imageLink link" target="_blank" rel="noreferrer">
+                                                    <span class="glyphicon glyphicon-camera"></span> Build image (using kupoconfig.com)
+                                                </a>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </div>
+                                <div id="clearBuildMenu" class="link text-center">
+                                    <div class="dropdown">
+                                        <a class=" dropdown-toggle link" type="button" data-toggle="dropdown">
+                                            <span class="glyphicon glyphicon-trash"></span> 
+                                            Clear <span class='hidden-xs'>items</span> <span class="caret"></span>
+                                        </a>
+                                        <ul class="dropdown-menu dropdown-menu-right">
+                                            <li>
+                                                <a class="link" onclick="clearItemsFromBuild(true)">
+                                                    <span class="glyphicon glyphicon-trash"></span> Clear not pinned items (for this build)
+                                                </a>
+                                            </li>
+                                            <li>
+                                                <a class="link" onclick="clearItemsFromBuild()">
+                                                    <span class="glyphicon glyphicon-trash"></span> Clear <strong>all</strong> items (for this build)
+                                                </a>
+                                            </li>
                                         </ul>
                                     </div>
                                 </div>

--- a/static/builder.js
+++ b/static/builder.js
@@ -1901,6 +1901,17 @@ function loadStateHashAndBuild(data, importMode = false) {
     window.location.hash = "";
 }
 
+function clearItemsFromBuild(keepPinnedItems = false)
+{
+    var buildItems = builds[currentUnitIndex].build;
+    var fixedItems = builds[currentUnitIndex].fixedItems;
+    for (var slot=0; slot < buildItems.length ; slot++) {
+        if (!keepPinnedItems || fixedItems[slot] === null) {
+            removeItemAt(slot);
+        }
+    }
+}
+
 function showBuildLink(onlyCurrentUnit) {
     var data = getStateHash(onlyCurrentUnit);
     


### PR DESCRIPTION

Implements #174 

Adds a button to clear items in current build.
Pinned items can be kept, or not.

While I was at it, the "Share this build" become "Share" for small screens.

### In Desktop view:
![image](https://user-images.githubusercontent.com/7137528/44618018-82418100-a86e-11e8-862b-34c377b2aca8.png)

### In Mobile view:
![image](https://user-images.githubusercontent.com/7137528/44618021-95545100-a86e-11e8-8286-681b90ba0669.png)
