### PR TITLE
Show more links while building

### DIFF
--- a/static/builder.css
+++ b/static/builder.css
@@ -696,15 +696,18 @@ i.img.img-slot-hand.leftHand {
 }
 
 /* elements visible over the glasspanel */
-.building #detailedViewLink, .building #conciseViewLink, .building #buildButton, .building #buildResult .wikiLink {
+.building #detailedViewLink, .building #conciseViewLink, .building #buildButton, .building #buildResult .wikiLink, 
+.building #unitLink, .building .footerButtons a {
     z-index: 110;
 }
 
-.building #buildButton, .building #detailedViewLink a, .building #conciseViewLink a, .building #buildResult .wikiLink {
+.building #buildButton, .building #detailedViewLink a, .building #conciseViewLink a, .building #buildResult .wikiLink, 
+.building #unitLink, .building .footerButtons a {
     box-shadow: 0 0 5px 5px #FFFFFF;
 }
 
-.building #detailedViewLink a, .building #conciseViewLink a, .building #buildResult .wikiLink {
+.building #detailedViewLink a, .building #conciseViewLink a, .building #buildResult .wikiLink, 
+.building #unitLink, .building .footerButtons a {
     background-color: white;
 }
 

--- a/static/common.css
+++ b/static/common.css
@@ -429,6 +429,7 @@ ul {
     text-decoration:line-through;
 }
 .buttonLink {
+    position: relative;
     cursor: pointer;
     margin-left: 10px;
     font-size: 0.9em;


### PR DESCRIPTION

As asked by @Darwe (Canine) on Discord:

> Small feature request - when a build is calculating, can the Unit Info link still be available? It might also be good to allow the reddit/discord/github/etc links to be available, so people can easily come ask questions or chat while long builds are running

![image](https://user-images.githubusercontent.com/7137528/44731186-ec625c00-aae2-11e8-9083-a4296225ef6f.png)

![image](https://user-images.githubusercontent.com/7137528/44731200-f2f0d380-aae2-11e8-864e-d9ccb4bfe8d6.png)
