### PR TITLE
Fix "Reset item exclusion list" creating infinite modals

### DIFF
--- a/static/builder.js
+++ b/static/builder.js
@@ -2240,6 +2240,7 @@ function removeItemFromExcludeList(id) {
 function resetExcludeList() {
     itemsToExclude = defaultItemsToExclude.slice();
     $(".excludedItemNumber").html(itemsToExclude.length);
+    Modal.hide();
     showExcludedItems();
 }
 


### PR DESCRIPTION
- Hide previous modal after button is clicked

Reference Issue: #235 