### PR TITLE
Fix overlay menu issue

### DIFF
--- a/static/common.css
+++ b/static/common.css
@@ -12,7 +12,7 @@
     position: relative;
     padding-top: 30px;
     margin-bottom: 20px;
-    z-index: 1;
+    z-index: 99;
 }
 
 #header .bannerPicture,

--- a/static/inventory.css
+++ b/static/inventory.css
@@ -331,6 +331,7 @@ a#exportLinks {
     position: absolute;
     top: 15px;
     left: 320px;
+    z-index: 1;
     margin-left: 10px;
     padding: 4px 6px;
     border: 1px solid #c8c8c8;

--- a/static/units.css
+++ b/static/units.css
@@ -287,6 +287,7 @@
     position: absolute;
     top: 20px;
     left: 320px;
+    z-index: 1;
 }
 
 #exportLinks a.dropdown-toggle {


### PR DESCRIPTION

Fix #240 once and for all.

Note that I reverted your commit on the zindex of the buttons.

Issue was regarding the stacking context root: `#header` had a z-index of only one. Simply setting it to 99 (below glass panel) is enough to work everywhere.