### PR TITLE
Build link fixes

### DIFF
--- a/static/builder.html
+++ b/static/builder.html
@@ -732,11 +732,6 @@
                                                     <span class="glyphicon glyphicon-list"></span> Build as text
                                                 </a>
                                             </li>
-                                            <li data-server="GL">
-                                                <a class="imageLink link" target="_blank" rel="noreferrer">
-                                                    <span class="glyphicon glyphicon-camera"></span> Build image (using kupoconfig.com)
-                                                </a>
-                                            </li>
                                         </ul>
                                     </div>
                                 </div>

--- a/static/builder.js
+++ b/static/builder.js
@@ -1,4 +1,4 @@
-page = "builder";
+﻿page = "builder";
 var adventurerIds = ["1500000013", "1500000015", "1500000016", "1500000017", "1500000018"];
 
 const formulaByGoal = {
@@ -2442,7 +2442,7 @@ function showBuildLink(onlyCurrentUnit) {
 function showBuildAsText() {
     var text = "";
     text += 
-        builds[currentUnitIndex].unit.name + ' ' + builds[currentUnitIndex].unit.max_rarity + '★  \n' +
+        builds[currentUnitIndex].unit.name + ' ' + builds[currentUnitIndex].unit.rarity + '★  \n' +
         getItemLineAsText("Right hand", 0) +
         getItemLineAsText("Left hand", 1) +
         getItemLineAsText("Head", 2) +


### PR DESCRIPTION
Removed "Build as Image" until Kupoconfig is updated.

Corrected "Build as Text" always calling the unit 7* even when built as 6*.