### PR TITLE
Update Builder's help documentation to reference THUNDER instead of LIGHTNING

### DIFF
--- a/static/builder.html
+++ b/static/builder.html
@@ -1155,7 +1155,7 @@
                                             <tr><td class="token">M_EVADE</td><td>Magical evade</td></tr>
                                             <tr><td class="token">EVO_MAG</td><td>Boost to Evocation damage</td></tr>
                                             <tr><td class="token">LB</td><td>Number of LB point generated each turn. Note that this number is heavilly dependant on the expected number of LB shards gained per turn.</td></tr>
-                                            <tr><td class="token">R_FIRE, R_ICE, R_LIGHTNING, R_WATER, R_EARTH, R_WIND, R_LIGHT, R_DARK</td><td>Corresponding elemental resistance</td></tr>
+                                            <tr><td class="token">R_FIRE, R_ICE, R_THUNDER, R_WATER, R_EARTH, R_WIND, R_LIGHT, R_DARK</td><td>Corresponding elemental resistance</td></tr>
                                             <tr><td class="token">R_POISON, R_BLIND, R_SLEEP, R_SILENCE, R_PARALYSIS, R_CONFUSION, R_DISEASE, R_PETRIFICATION, R_DEATH</td><td>Corresponding ailment resistance</td></tr>
                                         </tbody>
                                     </table>
@@ -1170,7 +1170,7 @@
                                             <tr><td class="token">I_POISON, I_BLIND, I_SLEEP, I_SILENCE, I_PARALYSIS, I_CONFUSION, I_DISEASE, I_PETRIFICATION, I_DEATH</td><td>I_XXX is a shortcut for R_XXX > 100</td></tr>
                                             <tr><td class="token">I_AILMENTS</td><td>This condition is a shortcut for all R_&lt;ailment&gt; > 100</td></tr>
                                             <tr><td class="token">I_DISABLE</td><td>This condition is a shortcut for I_SLEEP; I_PARALYSIS; I_CONFUSION; I_PETRIFICATION</td></tr>
-                                            <tr><td class="token">E_FIRE, E_ICE, E_LIGHTNING, E_WATER, E_EARTH, E_WIND, E_LIGHT, E_DARK</td><td>Those special conditions will force the resulting build to have the corresponding element(s) and no other elements</td></tr>
+                                            <tr><td class="token">E_FIRE, E_ICE, E_THUNDER, E_WATER, E_EARTH, E_WIND, E_LIGHT, E_DARK</td><td>Those special conditions will force the resulting build to have the corresponding element(s) and no other elements</td></tr>
                                             <tr><td class="token">E_NONE</td><td>Force a none elemental build. This condition is not compatible with E_FIRE, E_ICE, ...</td></tr>
                                         </tbody>
                                     </table>


### PR DESCRIPTION
I noticed that while both `R_LIGHTNING` and `R_THUNDER` will work for elemental resistances, only `E_THUNDER` currently works for elemental builds.  To try to keep some consistency, I updated help text for both to Thunder on the custom formulas section of the builder.

This will also fix issue #304 which mentions this.