### PR TITLE
updating Immortal Flame Katy as time-limited

### DIFF
--- a/static/GL/releasedUnits.json
+++ b/static/GL/releasedUnits.json
@@ -492,5 +492,5 @@
     "331000904" : {"type":"event","name":"Billy"},
     "304000405" : {"type":"event","name":"Flammie"},
     "304000503" : {"type":"event","name":"Rabite"},
-    "401007305" : {"type":"summon","name":"Immortal Flame Katy"}
+    "401007305" : {"type":"event","name":"Immortal Flame Katy"}
 }


### PR DESCRIPTION
As mentioned in issue #366, IF Katy is not currently flagged as time-limited; updated `releasedUnits.json` to correct