### PR TITLE
Removes CSP headers in dev environment

### DIFF
--- a/server.js
+++ b/server.js
@@ -70,7 +70,9 @@ if (config.isDev) {
   delete cspDirectives.reportUri;
 }
 
-app.use(helmet.contentSecurityPolicy({ directives: cspDirectives, reportOnly: !config.isDev }));
+if (!config.isDev) {
+  app.use(helmet.contentSecurityPolicy({ directives: cspDirectives }));
+}
 
 // Static middleware
 if (config.isProd || process.env.DEV_USE_DIST === "yes") {


### PR DESCRIPTION
The CSP headers included in the requests are causing failures with
fontawesome. This in turn is causing some functionality (like pinning or
banning specific items in the builders) to disappear.

This patch removes the CSP headers from requests if the app is launched
in dev mode. It does make the app vunlerable to XSS attacks but, hey,
it's dev mode. Don't run this in production anyway.

Fixes #507