### PR TITLE
Added removal of _BS to allow for proper URL construction.

### DIFF
--- a/static/common.js
+++ b/static/common.js
@@ -734,6 +734,11 @@ var toUrl = function(name) {
         return "";
     }
     let link = wikiBaseUrl + encodeURIComponent(name.replace(/ /g, '_'));
+    
+    if (link.includes('_BS')){
+        link = link.replace('_BS', '')
+    }
+
     if (server == 'JP') {
         link += '/JP';
     }


### PR DESCRIPTION
Added a small conditional to check if a unit name link includes _BS and if it does, replaces it with nothing.

This resolves the issue with Unit Search links redirecting to the wrong URL on the wiki.