### PR TITLE
Stat buff placeholder

### DIFF
--- a/static/builder.js
+++ b/static/builder.js
@@ -1629,7 +1629,7 @@ function displayUnitEnhancements() {
 function updateUnitStats() {
     $(baseStats).each(function (index, stat) {
         if (builds[currentUnitIndex].unit) {
-            $(".unitStats .stat." + stat + " .baseStat input").val(builds[currentUnitIndex].getStat(stat)); // .unitStats .stat.ATK .baseStat input
+            $(".unitStats .stat." + stat + " .baseStat input").val(builds[currentUnitIndex].getStat(stat));
             if (builds[currentUnitIndex].baseValues[stat].pots !== undefined) {
                 $(".unitStats .stat." + stat + " .pots input").val(builds[currentUnitIndex].baseValues[stat].pots);
             } else {

--- a/static/builder.js
+++ b/static/builder.js
@@ -1629,10 +1629,9 @@ function displayUnitEnhancements() {
 function updateUnitStats() {
     $(baseStats).each(function (index, stat) {
         if (builds[currentUnitIndex].unit) {
-            $(".unitStats .stat." + stat + " .baseStat input").val(builds[currentUnitIndex].getStat(stat));
+            $(".unitStats .stat." + stat + " .baseStat input").val(builds[currentUnitIndex].getStat(stat)); // .unitStats .stat.ATK .baseStat input
             if (builds[currentUnitIndex].baseValues[stat].pots !== undefined) {
                 $(".unitStats .stat." + stat + " .pots input").val(builds[currentUnitIndex].baseValues[stat].pots);
-                $(".unitStats .stat." + stat + " .buff input").val(builds[currentUnitIndex].baseValues[stat].buff);
             } else {
                 $(".unitStats .stat." + stat + " .pots input").val(Math.floor(builds[currentUnitIndex].unit.stats.pots[stat] * 1.5));
             }


### PR DESCRIPTION
The code removed automatically populated values with no value to 0, which was leading to users insert values greater than intended.

ie. 

with a populated 0, adding 300 would result in 3000.

By removing the prepopulation, placeholder 0s still show, but allow users to have the desired functionality to type in a full value.

Note: If you remove a value entirely from an input field and then click outside of it, the field will default to placeholder.